### PR TITLE
Fancier logging!

### DIFF
--- a/packages/ember-resolver/lib/core.js
+++ b/packages/ember-resolver/lib/core.js
@@ -113,7 +113,7 @@ define("resolver",
       }
 
       if (Ember.ENV.LOG_MODULE_RESOLVER) {
-        Ember.Logger.info('[*]', parsedName.fullName, new Array(40 - parsedName.fullName.length).join('.'), moduleName);
+        Ember.Logger.info('[✓]', parsedName.fullName, new Array(40 - parsedName.fullName.length).join('.'), moduleName);
       }
 
       return module;


### PR DESCRIPTION
Display both fullname as passed into the resolver and the module identifier that is requested via requirejs.

I think this makes it much easier to understand what the resolver is doing.

What do you think?
