### PR TITLE
Skip type normalization

### DIFF
--- a/packages/ember-resolver/lib/core.js
+++ b/packages/ember-resolver/lib/core.js
@@ -9,7 +9,7 @@ define("resolver",
    * important features:
    *
    *  1) The resolver makes the container aware of es6 modules via the AMD
-   *     output. The loader's _seen is consulted so that classes can be 
+   *     output. The loader's _seen is consulted so that classes can be
    *     resolved directly via the module loader, without needing a manual
    *     `import`.
    *  2) is able provide injections to classes that implement `extend`
@@ -20,7 +20,7 @@ define("resolver",
     return {
       create: function (injections) {
         if (typeof klass.extend === 'function') {
-          return klass.extend(injections);  
+          return klass.extend(injections);
         } else {
           return klass;
         }
@@ -142,7 +142,12 @@ define("resolver",
       // 1. `needs: ['posts/post']`
       // 2. `{{render "posts/post"}}`
       // 3. `this.render('posts/post')` from Route
-      return Ember.String.dasherize(fullName.replace(/\./g, '/'));
+      var split = fullName.split(':');
+      if (split.length > 1) {
+        return split[0] + ':' + Ember.String.dasherize(split[1].replace(/\./g, '/'));
+      } else {
+        return fullName;
+      }
     }
   });
 


### PR DESCRIPTION
Since we cannot [normalize a standalone type](https://github.com/emberjs/ember.js/blob/master/packages/ember-application/lib/system/resolver.js#L95), type injections are not normalized. However types are being normalized on registration.  This causes a mismatch between the type for injection and the registered type.

For example: `container.register('dataAdapter:main')` gets registered as `data-adapter:main`, but `container.injection('dataAdapter', 'store', 'store:main')` injects into `dataAdapter` and not `data-adapter`.
