### PR TITLE
Don't lock ember version.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
     "tests"
   ],
   "dependencies": {
-    "ember": "~> 1.2.0-beta.2"
+    "ember": "*"
   }
 }


### PR DESCRIPTION
Is there any reason to lock the ember version in bower.json? I'm trying to include the canary daily builds of ember and the locked dependency is causing problems.
