### PR TITLE
Very light refactor to the `chooseModuleName` function.

### DIFF
--- a/packages/ember-resolver/lib/core.js
+++ b/packages/ember-resolver/lib/core.js
@@ -68,12 +68,9 @@ define("ember/resolver",
     } else if (moduleEntries[underscoredModuleName]) {
       return underscoredModuleName;
     } else {
-      var parts = moduleName.split('/'),
-          lastPart = parts[parts.length - 1],
-          partializedModuleName;
-
-      parts[parts.length - 1] = lastPart.replace(/^-/, '_');
-      partializedModuleName = parts.join('/');
+      // workaround for dasherized partials:
+      // something/something/-something => something/something/_something
+      var partializedModuleName = moduleName.replace(/\/-([^\/]*)$/, '/_$1');
 
       if (moduleEntries[partializedModuleName]) {
         Ember.deprecate('Modules should not contain underscores. ' +


### PR DESCRIPTION
This changes it so it uses a single Regexp, instead of its previous
slightly more imperative logic. Nothing should change, overall, though
this could be a little faster.

The regexp `\/-([^\/]*)$` may be de constructed as follows:
- `\/-` **matches a slash followed by a dash**
- `([^\/]*)` **matches a group of any number of any character persides a
  slash
- `$` **matches the end of the string, so only the last 'part'
  (supposing parts are separated by slashes) will be matched

The `replace` call then, _matches the last 'part' beginning with a dash_
and then replaces it with the expression '/_$1'. In other words, the
supposedly matched slash, an underscore (which takes the place of the
dash) and the group matched between the dash and the end of the string
'$1'.

So:

``` javascript
'something/else/-wat'.replace(/\/-([^\/]*)$/, '/_$1');
// 'something/else/_wat'
```
