### PR TITLE
Don't log if logging is disabled

### DIFF
--- a/packages/ember-resolver/lib/core.js
+++ b/packages/ember-resolver/lib/core.js
@@ -168,7 +168,7 @@ define("ember/resolver",
       return tmpPrefix;
     },
 
-    /** 
+    /**
 
       A listing of functions to test for moduleName's based on the provided
       `parsedName`. This allows easy customization of additional module based
@@ -200,12 +200,14 @@ define("ember/resolver",
         }
 
         if (tmpModuleName && moduleEntries[tmpModuleName]) {
-          self._logLookup(true, parsedName, tmpModuleName);
+          if (!loggingDisabled) {
+            self._logLookup(true, parsedName, tmpModuleName);
+          }
 
           moduleName = tmpModuleName;
         }
 
-        if (!loggingDisabled && (Ember.ENV.LOG_MODULE_RESOLVER || parsedName.root.LOG_RESOLVER)) {
+        if (!loggingDisabled) {
           self._logLookup(moduleName, parsedName, tmpModuleName);
         }
 
@@ -226,6 +228,10 @@ define("ember/resolver",
 
     // only needed until 1.6.0-beta.2 can be required
     _logLookup: function(found, parsedName, description) {
+      if (!Ember.ENV.LOG_MODULE_RESOLVER && !parsedName.root.LOG_RESOLVER) {
+        return;
+      }
+
       var symbol, padding;
 
       if (found) { symbol = '[✓]'; }

--- a/packages/ember-resolver/tests/core_test.js
+++ b/packages/ember-resolver/tests/core_test.js
@@ -1,6 +1,6 @@
 /*globals define registry requirejs */
 
-var Resolver, resolver;
+var Resolver, resolver, logCalls, originalLog;
 
 function lookupResolver() {
   return requirejs.entries['ember/resolver'];
@@ -161,6 +161,42 @@ test("can lookup templates via Ember.TEMPLATES", function() {
 
   var template = resolver.resolve('template:application');
   ok(template, 'template should resolve');
+});
+
+module("Logging", {
+  setup: function() {
+    originalLog = Ember.Logger.log;
+    logCalls = [];
+    Ember.Logger.info = function(arg) { logCalls.push(arg); };
+  },
+
+  teardown: function() {
+    Ember.Logger.info = originalLog;
+  }
+});
+
+test("logs lookups when logging is enabled", function() {
+  define('appkit/fruits/orange', [], function(){
+    return 'is logged';
+  });
+
+  Ember.ENV.LOG_MODULE_RESOLVER = true;
+
+  resolver.resolve('fruit:orange');
+
+  ok(logCalls.length, "should log lookup");
+});
+
+test("doesn't log lookups if disabled", function() {
+  define('appkit/fruits/orange', [], function(){
+    return 'is not logged';
+  });
+
+  Ember.ENV.LOG_MODULE_RESOLVER = false;
+
+  resolver.resolve('fruit:orange');
+
+  equal(logCalls.length, 0, "should not log lookup");
 });
 
 module("custom prefixes by type", {


### PR DESCRIPTION
Previously this guard was in the logging method itself, should it be moved back there instead?
