### PR TITLE
Fix link to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ember JJ-Abrams Resolver [![Build Status](https://travis-ci.org/stefanpenner/ember-jj-abrams-resolver.png?branch=master)](https://travis-ci.org/stefanpenner/ember-jj-abrams-resolver)
+# Ember Resolver [![Build Status](https://travis-ci.org/stefanpenner/ember-resolver.svg?branch=master)](https://travis-ci.org/stefanpenner/ember-resolver)
 
 This project is tracking a new resolver based on ES6 semantics that has been extracted from (and used by) the following projects:
 

--- a/dist/ember-resolver-spade.js
+++ b/dist/ember-resolver-spade.js
@@ -2,7 +2,7 @@
 // Project:   Ember - JavaScript Application Framework
 // Copyright: Copyright 2013 Stefan Penner and Ember App Kit Contributors
 // License:   Licensed under MIT license
-//            See https://raw.github.com/stefanpenner/ember-jj-abrams-resolver/master/LICENSE
+//            See https://raw.github.com/stefanpenner/ember-resolver/master/LICENSE
 // ==========================================================================
 
 

--- a/dist/ember-resolver-tests.js
+++ b/dist/ember-resolver-tests.js
@@ -2,7 +2,7 @@
 // Project:   Ember - JavaScript Application Framework
 // Copyright: Copyright 2013 Stefan Penner and Ember App Kit Contributors
 // License:   Licensed under MIT license
-//            See https://raw.github.com/stefanpenner/ember-jj-abrams-resolver/master/LICENSE
+//            See https://raw.github.com/stefanpenner/ember-resolver/master/LICENSE
 // ==========================================================================
 
 

--- a/dist/ember-resolver.js
+++ b/dist/ember-resolver.js
@@ -2,7 +2,7 @@
 // Project:   Ember - JavaScript Application Framework
 // Copyright: Copyright 2013 Stefan Penner and Ember App Kit Contributors
 // License:   Licensed under MIT license
-//            See https://raw.github.com/stefanpenner/ember-jj-abrams-resolver/master/LICENSE
+//            See https://raw.github.com/stefanpenner/ember-resolver/master/LICENSE
 // ==========================================================================
 
 

--- a/dist/ember-resolver.min.js
+++ b/dist/ember-resolver.min.js
@@ -2,7 +2,7 @@
 // Project:   Ember - JavaScript Application Framework
 // Copyright: Copyright 2013 Stefan Penner and Ember App Kit Contributors
 // License:   Licensed under MIT license
-//            See https://raw.github.com/stefanpenner/ember-jj-abrams-resolver/master/LICENSE
+//            See https://raw.github.com/stefanpenner/ember-resolver/master/LICENSE
 // ==========================================================================
 
 

--- a/dist/ember-resolver.prod.js
+++ b/dist/ember-resolver.prod.js
@@ -2,7 +2,7 @@
 // Project:   Ember - JavaScript Application Framework
 // Copyright: Copyright 2013 Stefan Penner and Ember App Kit Contributors
 // License:   Licensed under MIT license
-//            See https://raw.github.com/stefanpenner/ember-jj-abrams-resolver/master/LICENSE
+//            See https://raw.github.com/stefanpenner/ember-resolver/master/LICENSE
 // ==========================================================================
 
 

--- a/generators/license.js
+++ b/generators/license.js
@@ -2,5 +2,5 @@
 // Project:   Ember - JavaScript Application Framework
 // Copyright: Copyright 2013 Stefan Penner and Ember App Kit Contributors
 // License:   Licensed under MIT license
-//            See https://raw.github.com/stefanpenner/ember-jj-abrams-resolver/master/LICENSE
+//            See https://raw.github.com/stefanpenner/ember-resolver/master/LICENSE
 // ==========================================================================

--- a/packages/ember-resolver/package.json
+++ b/packages/ember-resolver/package.json
@@ -2,7 +2,7 @@
   "name": "ember-resolver",
   "summary": "Ember Resolver Reboot",
   "description": "Ember Resolver Reboot",
-  "homepage": "https://github.com/stefanpenner/ember-jj-abrams-resolver",
+  "homepage": "https://github.com/stefanpenner/ember-resolver",
   "author": "Stefan Penner",
   "version": "0.0.1"
 }


### PR DESCRIPTION
Currently, `ember-jj-abrams-resolver` becomes `ember-resolver`.
