### PR TITLE
make podPrefix default to a /pods namespace

### DIFF
--- a/packages/ember-resolver/lib/core.js
+++ b/packages/ember-resolver/lib/core.js
@@ -193,13 +193,13 @@ define("ember/resolver",
     },
 
     podBasedModuleName: function(parsedName) {
-      var podPrefix = this.namespace.podModulePrefix || this.namespace.modulePrefix;
+      var podPrefix = this.podPrefix();
 
       return this.podBasedLookupWithPrefix(podPrefix, parsedName);
     },
 
     podBasedComponentsInSubdir: function(parsedName) {
-      var podPrefix = this.namespace.podModulePrefix || this.namespace.modulePrefix;
+      var podPrefix = this.podPrefix();
       podPrefix = podPrefix + '/components';
 
       if (parsedName.type === 'component' || parsedName.fullNameWithoutType.match(/^components/)) {
@@ -228,6 +228,10 @@ define("ember/resolver",
       }
 
       return tmpPrefix;
+    },
+
+    podPrefix: function() {
+      return this.namespace.podModulePrefix || this.namespace.modulePrefix + '/pods';
     },
 
     /**

--- a/packages/ember-resolver/tests/core_test.js
+++ b/packages/ember-resolver/tests/core_test.js
@@ -279,8 +279,8 @@ test("will lookup modulePrefix/name/type before prefix/type/name", function() {
     return 'whatever';
   });
 
-  define('appkit/foo/controller', [], function(){
-    ok(true, 'appkit/foo/controllers was used');
+  define('appkit/pods/foo/controller', [], function(){
+    ok(true, 'appkit/pods/foo/controllers was used');
     return 'whatever';
   });
 
@@ -293,8 +293,8 @@ test("will lookup names with slashes properly", function() {
     return 'whatever';
   });
 
-  define('appkit/foo/index/controller', [], function(){
-    ok(true, 'appkit/foo/index/controller was used');
+  define('appkit/pods/foo/index/controller', [], function(){
+    ok(true, 'appkit/pods/foo/index/controller was used');
     return 'whatever';
   });
 
@@ -305,7 +305,7 @@ test("specifying a podModulePrefix overrides the general modulePrefix", function
   setupResolver({
     namespace: {
       modulePrefix: 'appkit',
-      podModulePrefix: 'appkit/pods'
+      podModulePrefix: 'appkit/custom-pods'
     }
   });
 
@@ -319,8 +319,8 @@ test("specifying a podModulePrefix overrides the general modulePrefix", function
     return 'whatever';
   });
 
-  define('appkit/pods/foo/controller', [], function(){
-    ok(true, 'appkit/pods/foo/controllers was used');
+  define('appkit/custom-pods/foo/controller', [], function(){
+    ok(true, 'appkit/custom-pods/foo/controllers was used');
     return 'whatever';
   });
 
@@ -340,8 +340,8 @@ test("will not use custom type prefix when using POD format", function() {
     return 'whatever';
   });
 
-  define('appkit/foo/controller', [], function(){
-    ok(true, 'appkit/foo/controllers was used');
+  define('appkit/pods/foo/controller', [], function(){
+    ok(true, 'appkit/pods/foo/controllers was used');
     return 'whatever';
   });
 
@@ -349,13 +349,13 @@ test("will not use custom type prefix when using POD format", function() {
 });
 
 test("will lookup a components template without being rooted in `components/`", function() {
-  define('appkit/components/foo-bar/template', [], function(){
-    ok(false, 'appkit/components was used');
+  define('appkit/pods/components/foo-bar/template', [], function(){
+    ok(false, 'appkit/pods/components was used');
     return 'whatever';
   });
 
-  define('appkit/foo-bar/template', [], function(){
-    ok(true, 'appkit/foo-bar/template was used');
+  define('appkit/pods/foo-bar/template', [], function(){
+    ok(true, 'appkit/pods/foo-bar/template was used');
     return 'whatever';
   });
 
@@ -365,12 +365,12 @@ test("will lookup a components template without being rooted in `components/`", 
 test("will use pods format to lookup components in components/", function() {
   expect(2);
 
-  define('appkit/components/foo-bar/template', [], function(){
+  define('appkit/pods/components/foo-bar/template', [], function(){
     ok(true, 'appkit/components was used');
     return 'whatever';
   });
 
-  define('appkit/components/foo-bar/component', [], function(){
+  define('appkit/pods/components/foo-bar/component', [], function(){
     ok(true, 'appkit/components was used');
     return 'whatever';
   });


### PR DESCRIPTION
Should default to a /pods namespace based off the modulePrefix if podModulePrefix isn't set. 

closes #74 