### PR TITLE
Update dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,18 +1,14 @@
 {
   "name": "ember-resolver",
   "dependencies": {
-    "ember": "2.0.0",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.5",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.10",
-    "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "~0.1.20",
-    "jquery": "^1.11.3",
-    "loader.js": "ember-cli/loader.js#3.2.1",
+    "ember": "~2.0.0",
+    "ember-cli-shims": "ember-cli/ember-cli-shims#~0.0.5",
+    "ember-cli-test-loader": "~0.2.0",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#~0.1.6",
+    "ember-qunit": "~0.4.10",
+    "ember-qunit-notifications": "~0.0.7",
+    "jquery": ">= 1.11.3 < 2.2.0",
+    "loader.js": "~3.3.0",
     "qunit": "~1.18.0"
-  },
-  "resolutions": {
-    "ember": "2.0.0"
   }
 }


### PR DESCRIPTION
# Update dependencies

1. Update ember from "2.0.0" to "~2.0.0" so we could use ember 2.0.x (note 2.0.1 has been out)

2. Update jQuery to ">= 1.11.3 < 2.2.0" so we could use jQuery 2.x more conveniently. In fact, I think we could just delete it, since ember requires ">= 1.7.0 < 2.2.0"

3. Remove the dependency of itself

4. Update ember-load-initializers, ember-cli-test-loader and loader.js to latest version

5. Loosen dependencies by "~", so we could keep latest when they have minor upgrades