### PR TITLE
Bump self-reference in bower.json to latest version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.4.10",
     "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "~0.1.20",
+    "ember-resolver": "~2.0.3",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0"


### PR DESCRIPTION
New to the Ember world, so apologies if this is completely off-base - but it seemed like the self-reference in `bower.json` should be updated to match the latest version.  Otherwise, you would consistently get a message like:

```
Unable to find a suitable version for ember-resolver, please choose one:
    1) ember-resolver#~0.1.20 which resolved to 0.1.21 and is required by ember-resolver#2.0.3
    2) ember-resolver#~2.0.3 which resolved to 2.0.3 and is required by [APP_NAME]
```