### PR TITLE
Updating semver comparison to handle pre-release versions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
     var checker = new VersionChecker(this);
     var dep = checker.for('ember-cli', 'npm');
 
-    if (!dep.satisfies('>= 2.0.0')) {
+    if (dep.lt('2.0.0')) {
       this.monkeyPatchVendorFiles();
     }
 


### PR DESCRIPTION
Ran across this kind of randomly, but I noticed that `semver.satisifies('>= 2.0.0')` doesn't handle pre-release versions the way you'd think. (https://github.com/npm/node-semver#prerelease-tags)