### PR TITLE
Implement resolveEngine and resolveRouteMap

### DIFF
--- a/addon/resolver.js
+++ b/addon/resolver.js
@@ -181,6 +181,28 @@ var Resolver = DefaultResolver.extend({
     }
   },
 
+  resolveEngine(parsedName) {
+    let engineName = parsedName.fullNameWithoutType;
+    let engineModule = engineName + '/engine';
+
+    if (this._moduleRegistry.has(engineModule)) {
+      return this._extractDefaultExport(engineModule);
+    }
+  },
+
+  resolveRouteMap(parsedName) {
+    let engineName = parsedName.fullNameWithoutType;
+    let engineRoutesModule = engineName + '/routes';
+
+    if (this._moduleRegistry.has(engineRoutesModule)) {
+      let routeMap = this._extractDefaultExport(engineRoutesModule);
+
+      Ember.assert(`The route map for ${engineName} should be wrapped by 'buildRoutes' before exporting.` , routeMap.isRouteMap);
+
+      return routeMap;
+    }
+  },
+
   mainModuleName: function(parsedName) {
     // if router:main or adapter:main look for a module with just the type first
     var tmpModuleName = parsedName.prefix + '/' + parsedName.type;

--- a/tests/unit/resolver-test.js
+++ b/tests/unit/resolver-test.js
@@ -190,6 +190,53 @@ test("can lookup a view", function(assert) {
   assert.equal(view, expected, 'default export was returned');
 });
 
+test('can lookup an engine', function(assert) {
+  assert.expect(3);
+
+  let expected = {};
+  define('appkit/engine', [], function(){
+    assert.ok(true, 'engine was invoked properly');
+
+    return { default: expected };
+  });
+
+  let engine = resolver.resolve('engine:appkit');
+
+  assert.ok(engine, 'engine was returned');
+  assert.equal(engine, expected, 'default export was returned');
+});
+
+test('can lookup a route-map', function(assert) {
+  assert.expect(3);
+
+  let expected = { isRouteMap: true };
+  define('appkit/routes', [], function(){
+    assert.ok(true, 'route-map was invoked properly');
+
+    return { default: expected };
+  });
+
+  let routeMap = resolver.resolve('route-map:appkit');
+
+  assert.ok(routeMap, 'route-map was returned');
+  assert.equal(routeMap, expected, 'default export was returned');
+});
+
+test('errors if lookup of a route-map does not specify isRouteMap', function(assert) {
+  assert.expect(2);
+
+  let expected = { isRouteMap: false };
+  define('appkit/routes', [], function(){
+    assert.ok(true, 'route-map was invoked properly');
+
+    return { default: expected };
+  });
+
+  assert.throws(() => {
+    resolver.resolve('route-map:appkit');
+  }, /The route map for appkit should be wrapped by 'buildRoutes' before exporting/);
+});
+
 test("will return the raw value if no 'default' is available", function(assert) {
   define('appkit/fruits/orange', [], function(){
     return 'is awesome';


### PR DESCRIPTION
Addressing https://github.com/dgeb/ember-engines/issues/10.

One change to note: The `route-map` lookup now expects an `isRouteMap` property instead of trying to share a symbol between this addon and ember-engines.

cc @dgeb @rwjblue @nathanhammond 