### PR TITLE
Isaac/glimmer

### DIFF
--- a/mu-trees/addon/resolvers/glimmer-wrapper/index.js
+++ b/mu-trees/addon/resolvers/glimmer-wrapper/index.js
@@ -22,12 +22,12 @@ const Resolver = DefaultResolver.extend({
 
   normalize: null,
 
-  resolve(lookupString) {
-    return this._resolve(lookupString);
+  resolve(lookupString, referrer) {
+    return this._resolve(lookupString, referrer);
   },
 
-  _resolve(lookupString) {
-    return this._glimmerResolver.resolve(lookupString);
+  _resolve(lookupString, referrer) {
+    return this._glimmerResolver.resolve(lookupString, referrer);
   }
 });
 

--- a/mu-trees/tests/unit/module-registries/requirejs-test.js
+++ b/mu-trees/tests/unit/module-registries/requirejs-test.js
@@ -8,6 +8,7 @@ export let config = {
   },
   types: {
     component: { definitiveCollection: 'components' },
+    location: { definitiveCollection: 'locations' },
     partial: { definiteCollection: 'partials' },
     service: { definitiveCollection: 'services' },
     route: { definitiveCollection: 'routes' },
@@ -44,28 +45,57 @@ export let config = {
 
 module('RequireJS Registry', {
   beforeEach() {
-
     this.config = config;
-    this.registry = new RequireJSRegistry(this.config, 'src');
   }
 });
 
 test('Normalize', function(assert) {
-  assert.expect(10);
+  assert.expect(11);
+  this.registry = new RequireJSRegistry(this.config, 'src');
+
+  [
+    [ 'router:/my-app/main/main', 'my-app/src/router', '' ],
+    [ 'route:/my-app/routes/application', 'my-app/src/ui/routes/application', 'route' ],
+    [ 'template:/my-app/routes/application', 'my-app/src/ui/routes/application/template', '' ],
+    [ 'component:/my-app/components/my-input', 'my-app/src/ui/components/my-input', 'component' ],
+    [ 'template:/my-app/routes/components/my-input', 'my-app/src/ui/components/my-input/template', '' ],
+    [ 'template:/my-app/components/my-input', 'my-app/src/ui/components/my-input/template', '' ],
+    [ 'component:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button', 'component' ],
+    [ 'template:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/template', '' ],
+    [ 'template:/my-app/routes/-author', 'my-app/src/ui/partials/author', '' ],
+    [ 'service:/my-app/services/auth', 'my-app/src/services/auth', 'service' ],
+    [ 'location:/my-app/main/auth-dependent', 'my-app/src/locations/auth-dependent', 'location' ]
+  ]
+  .forEach(([ lookupString, path, type ]) => {
+    assert.deepEqual(this.registry.normalize(lookupString), { path, type }, `normalize ${lookupString} -> ${path}, ${type}`);
+  });
+});
+
+test('has', function(assert) {
+  assert.expect(16);
 
   [
     [ 'router:/my-app/main/main', 'my-app/src/router' ],
+    [ 'route:/my-app/routes/application', 'my-app/src/ui/routes/application' ],
     [ 'route:/my-app/routes/application', 'my-app/src/ui/routes/application/route' ],
     [ 'template:/my-app/routes/application', 'my-app/src/ui/routes/application/template' ],
+    [ 'component:/my-app/components/my-input', 'my-app/src/ui/components/my-input' ],
     [ 'component:/my-app/components/my-input', 'my-app/src/ui/components/my-input/component' ],
     [ 'template:/my-app/routes/components/my-input', 'my-app/src/ui/components/my-input/template' ],
     [ 'template:/my-app/components/my-input', 'my-app/src/ui/components/my-input/template' ],
+    [ 'component:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button' ],
     [ 'component:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/component' ],
     [ 'template:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/template' ],
     [ 'template:/my-app/routes/-author', 'my-app/src/ui/partials/author' ],
-    [ 'service:/my-app/services/auth', 'my-app/src/services/auth/service' ]
+    [ 'service:/my-app/services/auth', 'my-app/src/services/auth' ],
+    [ 'service:/my-app/services/auth', 'my-app/src/services/auth/service' ],
+    [ 'location:/my-app/main/auth-dependent', 'my-app/src/locations/auth-dependent' ],
+    [ 'location:/my-app/main/auth-dependent', 'my-app/src/locations/auth-dependent/location' ]
   ]
-  .forEach(([ lookupString, expected ]) => {
-    assert.equal(this.registry.normalize(lookupString), expected, `normalize ${lookupString} -> ${expected}`);
+  .forEach(([ lookupString, expectedPath ]) => {
+    const mockEntries = [];
+    mockEntries[expectedPath] = true;
+    this.registry = new RequireJSRegistry(this.config, 'src', { entries: mockEntries });
+    assert.ok(this.registry.has(lookupString), `registry has ${lookupString} at ${expectedPath}`);
   });
 });

--- a/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
+++ b/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
@@ -325,3 +325,87 @@ test('Can resolve a top level template of a definitive type', function(assert) {
     'relative module specifier with source resolved'
   );
 });
+
+test('Can resolve a private component & template for a route using local lookup; nested under /-components', function(assert) {
+  let template = {};
+  let component = {};
+  let componentTemplate = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      component: { definitiveCollection: 'components' },
+      route: { definitiveCollection: 'routes' },
+      template: { definitiveCollection: 'components' }
+    },
+    collections: {
+      components: {
+        group: 'ui',
+        types: [ 'component', 'template' ]
+      },
+      routes: {
+        group: 'ui',
+        types: [ 'route', 'template' ]
+      }
+    }
+  }, {
+    'template:/app/routes/posts': template,
+    'template:/app/routes/posts/-components/my-input': componentTemplate,
+    'component:/app/routes/posts/-components/my-input': component
+  });
+
+  assert.equal(
+    resolver.resolve('component:my-input', 'template:/app/routes/posts/-components'),
+    component,
+    'relative component module specifier with source resolved'
+  );
+
+  assert.equal(
+    resolver.resolve('template:my-input', 'template:/app/routes/posts/-components'),
+    componentTemplate,
+    'relative template module specifier with source resolved'
+  );
+});
+
+test('Can resolve a private component & template belonging to another component using local lookup', function(assert) {
+  let template = {};
+  let component = {};
+  let componentTemplate = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      component: { definitiveCollection: 'components' },
+      route: { definitiveCollection: 'routes' },
+      template: { definitiveCollection: 'components' }
+    },
+    collections: {
+      components: {
+        group: 'ui',
+        types: [ 'component', 'template' ]
+      },
+      routes: {
+        group: 'ui',
+        types: [ 'route', 'template' ]
+      }
+    }
+  }, {
+    'template:/app/components/my-post': template,
+    'template:/app/components/my-post/my-input': componentTemplate,
+    'component:/app/components/my-post/my-input': component
+  });
+
+  assert.equal(
+    resolver.resolve('template:my-input', 'template:/app/components/my-post'),
+    componentTemplate,
+    'relative template module specifier with source resolved'
+  );
+
+  assert.equal(
+    resolver.resolve('component:my-input', 'template:/app/components/my-post'),
+    component,
+    'relative component module specifier with source resolved'
+  );
+});


### PR DESCRIPTION
@mixonic This adds a couple of things to the ember-resolver to support Module Unification:

 - (first commit) Looks up certain types like services and utils in two possible places, for example, for `service:auth`, check `my-app/src/ui/services/auth` and `my-app/src/ui/services/auth/service`

- (second commit) Add tests for local lookup. This verifies that local lookup works as implemented in the `@glimmer/resolver`, provided that we (via ember) pass the correct value for `referrer`. These tests make explicit what we expect so that we can implement the right thing in Ember. Ember should pass the absolute specifier for the template, adding `/-components` at the end if it is coming from a route template. For example:
    * If looking from a route called `posts`: referrer: `template:/app/routes/post/-components`
    * If looking from a component called `my-input`: referrer: `template:/app/components/my-input`