### PR TITLE
Assert against get, not normalize

### DIFF
--- a/mu-trees/addon/module-registries/requirejs.js
+++ b/mu-trees/addon/module-registries/requirejs.js
@@ -5,12 +5,13 @@ import {
 
 export default class RequireJSRegistry {
 
-  constructor(config, modulePrefix) {
+  constructor(config, modulePrefix, require=self.requirejs) {
     this._config = config;
     this._modulePrefix = modulePrefix;
+    this._require = require;
   }
 
-  normalize(specifier) {
+  _normalize(specifier) {
     let s = deserializeSpecifier(specifier);
 
     // This is hacky solution to get around the fact that Ember
@@ -31,10 +32,10 @@ export default class RequireJSRegistry {
       segments.push(group);
     }
 
-    // Special case to handle definiteCollection for templates
+    // Special case to handle definitiveCollection for templates
     // eventually want to find a better way to address.
     // Dgeb wants to find a better way to handle these
-    // in config without needing definiteCollections.
+    // in config without needing definitiveCollection.
     let ignoreCollection = s.type === 'template' &&
       s.collection === 'routes' &&
       s.namespace === 'components';
@@ -61,12 +62,15 @@ export default class RequireJSRegistry {
   }
 
   has(specifier) {
-    let path = this.normalize(specifier);
-    return path in requirejs.entries;
+    let path = this._normalize(specifier);
+    // Worth noting this does not confirm there is a default export,
+    // as would be expected with this simple implementation of the module
+    // registry.
+    return path in this._require.entries;
   }
 
   get(specifier) {
-    let path = this.normalize(specifier);
-    return require(path).default;
+    let path = this._normalize(specifier);
+    return this._require(path).default;
   }
 }

--- a/mu-trees/tests/unit/module-registries/requirejs-test.js
+++ b/mu-trees/tests/unit/module-registries/requirejs-test.js
@@ -42,11 +42,17 @@ export let config = {
   }
 };
 
+function buildMockRequire() {
+  let mockRequire = modulePath => mockRequire.entries[modulePath];
+  mockRequire.entries = {};
+  return mockRequire;
+}
+
 module('RequireJS Registry', {
   beforeEach() {
-
+    this.mockRequire = buildMockRequire();
     this.config = config;
-    this.registry = new RequireJSRegistry(this.config, 'src');
+    this.registry = new RequireJSRegistry(this.config, 'src', this.mockRequire);
   }
 });
 
@@ -66,6 +72,11 @@ test('Normalize', function(assert) {
     [ 'service:/my-app/services/auth', 'my-app/src/services/auth/service' ]
   ]
   .forEach(([ lookupString, expected ]) => {
-    assert.equal(this.registry.normalize(lookupString), expected, `normalize ${lookupString} -> ${expected}`);
+    let expectedModule = {};
+    this.mockRequire.entries = {
+      [expected]: {default: expectedModule}
+    };
+    let actualModule = this.registry.get(lookupString);
+    assert.equal(actualModule, expectedModule, `normalize ${lookupString} -> ${expected}`);
   });
 });


### PR DESCRIPTION
Allow requirejs to be passed to the module registry, avoid testing the internal `_normalize` method.