### PR TITLE
defaultType support, mv partials code to resolver

### DIFF
--- a/mu-trees/addon/ember-config.js
+++ b/mu-trees/addon/ember-config.js
@@ -36,7 +36,6 @@ export default function generateConfig(name) {
         }
       },
       transform: { definitiveCollection: 'transforms' },
-      util: { definitiveCollection: 'utils' },
       view: { definitiveCollection: 'views' },
       '-view-registry': { definitiveCollection: 'main' },
       '-bucket-cache': { definitiveCollection: 'main' }
@@ -47,40 +46,55 @@ export default function generateConfig(name) {
       },
       components: {
         group: 'ui',
+        privateCollections: ['utils'],
         types: ['component', 'helper', 'template']
       },
       initializers: {
         group: 'init',
+        defaultType: 'initializer',
+        privateCollections: ['utils'],
         types: ['initializer']
       },
       'instance-initializers': {
         group: 'init',
+        defaultType: 'instance-initializer',
+        privateCollections: ['utils'],
         types: ['instance-initializers']
       },
       models: {
         group: 'data',
+        defaultType: 'model',
+        privateCollections: ['utils'],
         types: ['model', 'adapter', 'serializer']
       },
       partials: {
         group: 'ui',
+        defaultType: 'partial',
+        privateCollections: ['utils'],
         types: ['partial']
       },
       routes: {
         group: 'ui',
-        privateCollections: ['components'],
+        privateCollections: ['components', 'utils'],
         types: ['route', 'controller', 'template']
       },
       services: {
+        defaultType: 'service',
+        privateCollections: ['utils'],
         types: ['service']
       },
       utils: {
         unresolvable: true
       },
       views: {
+        defaultType: 'view',
+        privateCollections: ['utils'],
         types: ['view']
       },
       transforms: {
         group: 'data',
+        defaultType: 'transform',
+        privateCollections: ['utils'],
         types: ['transform']
       }
     }

--- a/mu-trees/addon/resolvers/glimmer-wrapper/index.js
+++ b/mu-trees/addon/resolvers/glimmer-wrapper/index.js
@@ -4,6 +4,8 @@ import RequireJSRegistry from '../../module-registries/requirejs';
 
 const { DefaultResolver } = Ember;
 
+const TEMPLATE_TO_PARTIAL = /^template:(.*\/)?_([\w-]+)/;
+
 /*
  * Wrap the @glimmer/resolver in Ember's resolver API. Although
  * this code extends from the DefaultResolver, it should never
@@ -23,11 +25,36 @@ const Resolver = DefaultResolver.extend({
   normalize: null,
 
   resolve(lookupString) {
+    /*
+     * Ember paritals are looked up as templates. Here we replace the template
+     * resolution with a partial resolute when appropriate. Try to keep this
+     * code as "pay-go" as possible.
+     */
+
+    if (lookupString.indexOf('template:') === 0) {
+      lookupString = this._templateToPartial(lookupString);
+    }
     return this._resolve(lookupString);
   },
 
   _resolve(lookupString) {
     return this._glimmerResolver.resolve(lookupString);
+  },
+
+  /*
+   * templates may actually be partial lookups, so consider them as possibly
+   * such and return the correct lookupString.
+   */
+  _templateToPartial(lookupString) {
+    let match = TEMPLATE_TO_PARTIAL.exec(lookupString);
+    if (!match) {
+      return lookupString;
+    }
+
+    let namespace = match[1] || '';
+    let name = match[2];
+
+    return `partial:${namespace}${name}`;
   }
 });
 

--- a/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
+++ b/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
@@ -325,3 +325,30 @@ test('Can resolve a top level template of a definitive type', function(assert) {
     'relative module specifier with source resolved'
   );
 });
+
+test('Can resolve a partial', function(assert) {
+  let template = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      partial: { definitiveCollection: 'partials' }
+    },
+    collections: {
+      partials: {
+        group: 'ui',
+        defaultType: 'partial',
+        types: ['partial']
+      }
+    }
+  }, {
+    'partial:/app/partials/author': template
+  });
+
+  assert.equal(
+    resolver.resolve('template:_author', ''),
+    template,
+    'partial resolved'
+  );
+});


### PR DESCRIPTION
* Add `defaultType` to the Ember resolver config.
* Use the `defaultType` in `RequireJSRegistry` to optionally check for the non-typed path.
* Move the path conversion for partials into the Ember resolver and out of the module registry.

Closes: https://github.com/ember-cli/ember-resolver/issues/189
Replaces: https://github.com/ember-cli/ember-resolver/pull/183