### PR TITLE
Normalize referrer and lookupString, add config flag

### DIFF
--- a/mu-trees/addon/ember-config.js
+++ b/mu-trees/addon/ember-config.js
@@ -29,12 +29,7 @@ export default function generateConfig(name) {
       router: { definitiveCollection: 'main' },
       serializer: { definitiveCollection: 'models' },
       service: { definitiveCollection: 'services' },
-      template: {
-        definitiveCollection: 'routes',
-        fallbackCollectionPrefixes: {
-          'components': 'components'
-        }
-      },
+      template: { definitiveCollection: 'components' },
       transform: { definitiveCollection: 'transforms' },
       view: { definitiveCollection: 'views' },
       '-view-registry': { definitiveCollection: 'main' },

--- a/mu-trees/addon/resolvers/glimmer-wrapper/index.js
+++ b/mu-trees/addon/resolvers/glimmer-wrapper/index.js
@@ -15,6 +15,8 @@ const Resolver = DefaultResolver.extend({
   init() {
     this._super(...arguments);
 
+    this._configRootName = this.config.app.rootName || 'app';
+
     if (!this.glimmerModuleRegistry) {
       this.glimmerModuleRegistry = new RequireJSRegistry(this.config, 'src');
     }
@@ -24,38 +26,50 @@ const Resolver = DefaultResolver.extend({
 
   normalize: null,
 
-  resolve(lookupString) {
-    /*
-     * Ember paritals are looked up as templates. Here we replace the template
-     * resolution with a partial resolute when appropriate. Try to keep this
-     * code as "pay-go" as possible.
-     */
+  resolve(lookupString, referrer) {
 
-    if (lookupString.indexOf('template:') === 0) {
-      lookupString = this._templateToPartial(lookupString);
+    if (lookupString.indexOf('template:components/') === 0) {
+      /*
+       * Ember components require their lookupString to be massaged. Make this
+       * as "pay-go" as possible.
+       */
+      if (referrer) {
+        // make absolute
+        let parts = referrer.split(':src/ui/');
+        referrer = `${parts[0]}:/${this._configRootName}/${parts[1]}`;
+        referrer = referrer.split('/template.hbs')[0];
+      }
+
+      lookupString = lookupString.replace('components/', '');
+    } else if (lookupString.indexOf('template:') === 0) {
+      /*
+       * Ember partials are looked up as templates. Here we replace the template
+       * resolution with a partial resolute when appropriate. Try to keep this
+       * code as "pay-go" as possible.
+       */
+      let match = TEMPLATE_TO_PARTIAL.exec(lookupString);
+      if (match) {
+        let namespace = match[1] || '';
+        let name = match[2];
+
+        lookupString = `partial:${namespace}${name}`;
+      } else {
+        if (referrer) {
+          throw new Error(`Cannot look up a route template ${lookupString} with a referrer`);
+        }
+        let parts = lookupString.split(':');
+        lookupString = `template`;
+        referrer = `route:/${this._configRootName}/routes/${parts[1]}`;
+      }
     }
-    return this._resolve(lookupString);
+
+    return this._resolve(lookupString, referrer);
   },
 
-  _resolve(lookupString) {
-    return this._glimmerResolver.resolve(lookupString);
-  },
-
-  /*
-   * templates may actually be partial lookups, so consider them as possibly
-   * such and return the correct lookupString.
-   */
-  _templateToPartial(lookupString) {
-    let match = TEMPLATE_TO_PARTIAL.exec(lookupString);
-    if (!match) {
-      return lookupString;
-    }
-
-    let namespace = match[1] || '';
-    let name = match[2];
-
-    return `partial:${namespace}${name}`;
+  _resolve(lookupString, referrer) {
+    return this._glimmerResolver.resolve(lookupString, referrer);
   }
+
 });
 
 export default Resolver;

--- a/mu-trees/tests/unit/module-registries/requirejs-test.js
+++ b/mu-trees/tests/unit/module-registries/requirejs-test.js
@@ -12,12 +12,7 @@ export let config = {
     service: { definitiveCollection: 'services' },
     route: { definitiveCollection: 'routes' },
     router: { definitiveCollection: 'main' },
-    template: {
-      definitiveCollection: 'routes',
-      fallbackCollectionPrefixes: {
-        'components': 'components'
-      }
-    }
+    template: { definitiveCollection: 'components' }
   },
   collections: {
     'main': {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "@glimmer/resolver": "^0.3.0",
+    "@glimmer/resolver": "0.4.0",
     "babel-plugin-debug-macros": "^0.1.1",
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
 
-"@glimmer/resolver@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/resolver/-/resolver-0.3.0.tgz#65451a2195259ce26518715631c38dd7c144e821"
+"@glimmer/resolver@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/resolver/-/resolver-0.4.0.tgz#7fe8709342064f144c14c06088d6dc4070ad7d1d"
   dependencies:
     "@glimmer/di" "^0.2.0"
 


### PR DESCRIPTION
* The referrer from Ember is not an absolute specifier. Do some string
  munging to clean it up. We would like this to be a build step
  on Ember template compilation at some point.
* Ember tries to namespace components with `components/` as a specifier
  namespace. Drop that, since MU rules say to look in the components
  collection anyway.
* Add config to disable templates from being resolved locally in routes.

Supersedes https://github.com/ember-cli/ember-resolver/pull/196, compatible with https://github.com/glimmerjs/glimmer-resolver/pull/17