### PR TITLE
make referrer absolute for all lookups

### DIFF
--- a/mu-trees/addon/resolvers/glimmer-wrapper/index.js
+++ b/mu-trees/addon/resolvers/glimmer-wrapper/index.js
@@ -27,19 +27,18 @@ const Resolver = DefaultResolver.extend({
   normalize: null,
 
   resolve(lookupString, referrer) {
+    /*
+     * Ember components require their lookupString to be massaged. Make this
+     * as "pay-go" as possible.
+     */
+    if (referrer) {
+      // make absolute
+      let parts = referrer.split(':src/ui/');
+      referrer = `${parts[0]}:/${this._configRootName}/${parts[1]}`;
+      referrer = referrer.split('/template.hbs')[0];
+    }
 
     if (lookupString.indexOf('template:components/') === 0) {
-      /*
-       * Ember components require their lookupString to be massaged. Make this
-       * as "pay-go" as possible.
-       */
-      if (referrer) {
-        // make absolute
-        let parts = referrer.split(':src/ui/');
-        referrer = `${parts[0]}:/${this._configRootName}/${parts[1]}`;
-        referrer = referrer.split('/template.hbs')[0];
-      }
-
       lookupString = lookupString.replace('components/', '');
     } else if (lookupString.indexOf('template:') === 0) {
       /*

--- a/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
+++ b/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
@@ -502,3 +502,113 @@ test('Does not fall back when resolving route', function(assert) {
     'relative module found in routes'
   );
 });
+
+test('Can resolve a local component for a route', function(assert) {
+  let component = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      component: { definitiveCollection: 'components' },
+      route: { definitiveCollection: 'routes' },
+      template: { definitiveCollection: 'components' }
+    },
+    collections: {
+      components: {
+        group: 'ui',
+        types: [ 'component', 'template' ]
+      },
+      routes: {
+        group: 'ui',
+        types: [ 'route', 'template' ]
+      }
+    }
+  }, {
+    'component:/app/routes/posts/-components/my-input': component
+  });
+
+  assert.equal(
+    resolver.resolve('component:my-input', 'template:src/ui/routes/posts'),
+    component,
+    'component resolved'
+  );
+  assert.equal(
+    resolver.resolve('component:my-input'),
+    undefined,
+    'component not resolved at global level'
+  );
+});
+
+test('Can resolve a local component for another component', function(assert) {
+  let component = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      component: { definitiveCollection: 'components' },
+      route: { definitiveCollection: 'routes' },
+      template: { definitiveCollection: 'components' }
+    },
+    collections: {
+      components: {
+        group: 'ui',
+        types: [ 'component', 'template' ]
+      },
+      routes: {
+        group: 'ui',
+        types: [ 'route', 'template' ]
+      }
+    }
+  }, {
+    'component:/app/components/my-parent/my-input': component
+  });
+
+  assert.equal(
+    resolver.resolve('component:my-input', 'template:src/ui/components/my-parent'),
+    component,
+    'component resolved'
+  );
+  assert.equal(
+    resolver.resolve('component:my-input'),
+    undefined,
+    'component not resolved at global levelt'
+  );
+});
+
+test('Can resolve a local helper for another component', function(assert) {
+  let helper = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      component: { definitiveCollection: 'components' },
+      helper: { definitiveCollection: 'components' }
+    },
+    collections: {
+      components: {
+        group: 'ui',
+        types: [ 'component', 'template' ]
+      },
+      routes: {
+        group: 'ui',
+        types: [ 'route', 'template' ]
+      }
+    }
+  }, {
+    'helper:/app/components/my-parent/my-input': helper
+  });
+
+  assert.equal(
+    resolver.resolve('helper:my-input', 'template:src/ui/components/my-parent'),
+    helper,
+    'helper resolved'
+  );
+  assert.equal(
+    resolver.resolve('helper:my-input'),
+    undefined,
+    'helper not resolved at global levelt'
+  );
+});


### PR DESCRIPTION
Without this, for local lookup, the resolver will correctly resolve local templates, but not components and helpers.

@mixonic 