### PR TITLE
Support named exports

### DIFF
--- a/mu-trees/tests/unit/module-registries/requirejs-test.js
+++ b/mu-trees/tests/unit/module-registries/requirejs-test.js
@@ -118,3 +118,14 @@ test('un-typed module name with default export when resolved type is not the def
     `did not resolve the module`
   );
 });
+
+test('un-typed module name with named export of resolved type', function(assert) {
+  let expectedModule = {};
+  this.addModule(`my-app/src/ui/routes/index`, {template: expectedModule});
+
+  let actualModule = this.registry.get(`template:/my-app/routes/index`);
+  assert.equal(
+    actualModule, expectedModule,
+    `did not resolve the module`
+  );
+});


### PR DESCRIPTION
Support named exports in the `RequireJSRegistry`.

This implementation will only check for a default export if a module is the default type in a collection. /cc @dgeb 

Additionally it causes modules to be evaluated just to read their exports list. This is something that should be done at build time. I have concerns about the implications of evaluating modules just to get their exports (both in term of understanding when code in an app runs and performance). We can greatly improve this via a build-time map or by adding a description of named exports to the loader.js API.