### PR TITLE
resolve nested routes

### DIFF
--- a/mu-trees/addon/resolvers/glimmer-wrapper/index.js
+++ b/mu-trees/addon/resolvers/glimmer-wrapper/index.js
@@ -38,6 +38,7 @@ const Resolver = DefaultResolver.extend({
       referrer = referrer.split('/template.hbs')[0];
     }
 
+    lookupString = lookupString.replace(/\./g, '/');
     if (lookupString.indexOf('template:components/') === 0) {
       lookupString = lookupString.replace('components/', '');
     } else if (lookupString.indexOf('template:') === 0) {

--- a/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
+++ b/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
@@ -612,3 +612,38 @@ test('Can resolve a local helper for another component', function(assert) {
     'helper not resolved at global levelt'
   );
 });
+
+test('Can resolve nested routes with dots in the path', function(assert) {
+  let route = {};
+  let template = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      template: { definitiveCollection: 'components' },
+      route: { definitiveCollection: 'routes' }
+    },
+    collections: {
+      routes: {
+        group: 'ui',
+        types: [ 'route', 'template' ]
+      }
+    }
+  }, {
+    'route:/app/routes/posts/author/bio': route,
+    'template:/app/routes/posts/author/bio': template
+  });
+
+  assert.equal(
+    resolver.resolve('route:posts.author.bio'),
+    route,
+    'route resolved'
+  );
+
+  assert.equal(
+    resolver.resolve('template:posts.author.bio'),
+    template,
+    'template resolved'
+  );
+});


### PR DESCRIPTION
@mixonic @dgeb Fixes nested route lookups in module unification. Previously, when looking up `route:posts.author.bio`, the glimmer resolver would looking up a top-level route with the name `posts.author.bio`. By replacing all dots with slashes, it looks up in the correct place.