### PR TITLE
Update ember-cli-version-checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^6.3.0",
-    "ember-cli-version-checker": "1.3.1",
+    "ember-cli-version-checker": "^2.0.0",
     "resolve": "^1.3.3"
   },
   "ember-addon": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,7 +1902,7 @@ ember-cli-valid-component-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-version-checker@1.3.1, ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7:
+ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
   dependencies:


### PR DESCRIPTION
The presence of ember-cli-version-checker prior to 2.0.0 anywhere in an app's dependencies makes it impossible to use dependencies that are hoisted above the ember app's root directory. Now that yarn has workspaces support, that's not an unreasonable thing to want to do.