### PR TITLE
Add support to glimmer-wrapper for MU namespaces

### DIFF
--- a/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
+++ b/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
@@ -723,3 +723,56 @@ test('Can resolve a local helper for another component', function(assert) {
     'helper not resolved at global levelt'
   );
 });
+
+// Namespaces
+
+test('Can resolve a namespaced service lookup', function(assert) {
+  let service = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      service: { definitiveCollection: 'services' }
+    },
+    collections: {
+      services: {
+        types: [ 'service' ]
+      }
+    }
+  }, {
+    'service:/other-namespace/services/i18n': service
+  });
+
+  assert.equal(
+    resolver.resolve('service', null, 'other-namespace::i18n'),
+    service,
+    'namespaced resolution resolved'
+  );
+});
+
+test('Can resolve a namespaced component template', function(assert) {
+  let template = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      template: { definitiveCollection: 'components' }
+    },
+    collections: {
+      components: {
+        group: 'ui',
+        types: [ 'template' ]
+      }
+    }
+  }, {
+    'template:/other-namespace/components/my-component': template
+  });
+
+  assert.equal(
+    resolver.resolve('template:components/', null, 'other-namespace::my-component'),
+    template,
+    'namespaced resolution resolved'
+  );
+});


### PR DESCRIPTION
resolver.resolve now takes a third argument `rawString` which is the
string used at the invocation site of the lookup. For example for:

```
{{ember-power-select::option}}
```

The lookup should be:

```
resolver.resolve('template:component/', null, 'ember-power-select::option')
```

And for a service example:

```
Ember.service.inject('auth-addon::main-service')
```

The lookup would be:

```
resolver.resolve('service', null, 'auth-addon::main-service')
```

Refs: https://github.com/ember-cli/ember-resolver/issues/214
Refs: https://github.com/emberjs/ember.js/issues/15350#issuecomment-328118310

TODO:

* [x] land https://github.com/glimmerjs/glimmer-resolver/pull/20 upstream and include the version bump here.