### PR TITLE
Support mu namespaced in lookup string in glimmer wrapper

### DIFF
--- a/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
+++ b/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
@@ -723,3 +723,56 @@ test('Can resolve a local helper for another component', function(assert) {
     'helper not resolved at global levelt'
   );
 });
+
+// Namespaces
+
+test('Can resolve a namespaced service lookup', function(assert) {
+  let service = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      service: { definitiveCollection: 'services' }
+    },
+    collections: {
+      services: {
+        types: [ 'service' ]
+      }
+    }
+  }, {
+    'service:/other-namespace/services/i18n': service
+  });
+
+  assert.equal(
+    resolver.resolve('service', null, 'other-namespace::i18n'),
+    service,
+    'namespaced resolution resolved'
+  );
+});
+
+test('Can resolve a namespaced component template', function(assert) {
+  let template = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      template: { definitiveCollection: 'components' }
+    },
+    collections: {
+      components: {
+        group: 'ui',
+        types: [ 'template' ]
+      }
+    }
+  }, {
+    'template:/other-namespace/components/my-component': template
+  });
+
+  assert.equal(
+    resolver.resolve('template:components/', null, 'other-namespace::my-component'),
+    template,
+    'namespaced resolution resolved'
+  );
+});

--- a/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
+++ b/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
@@ -745,7 +745,7 @@ test('Can resolve a namespaced service lookup', function(assert) {
   });
 
   assert.equal(
-    resolver.resolve('service', null, 'other-namespace::i18n'),
+    resolver.resolve('service:other-namespace::i18n'),
     service,
     'namespaced resolution resolved'
   );
@@ -771,8 +771,34 @@ test('Can resolve a namespaced component template', function(assert) {
   });
 
   assert.equal(
-    resolver.resolve('template:components/', null, 'other-namespace::my-component'),
+    resolver.resolve('template:components/other-namespace::my-component'),
     template,
+    'namespaced resolution resolved'
+  );
+});
+
+test('Can resolve a namespaced component', function(assert) {
+  let component = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      component: { definitiveCollection: 'components' }
+    },
+    collections: {
+      components: {
+        group: 'ui',
+        types: [ 'component' ]
+      }
+    }
+  }, {
+    'component:/other-namespace/components/my-component': component
+  });
+
+  assert.equal(
+    resolver.resolve('component:other-namespace::my-component'),
+    component,
     'namespaced resolution resolved'
   );
 });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@glimmer/resolver": "^0.4.1",
+    "@glimmer/resolver": "^0.4.2",
     "babel-plugin-debug-macros": "^0.1.10",
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,9 +48,9 @@
   dependencies:
     "@glimmer/util" "^0.22.3"
 
-"@glimmer/resolver@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/resolver/-/resolver-0.4.1.tgz#cd9644572c556e7e799de1cf8eff2b999cf5b878"
+"@glimmer/resolver@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@glimmer/resolver/-/resolver-0.4.2.tgz#60c9b492e90bc3956ac82b3134649bd337e1651c"
   dependencies:
     "@glimmer/di" "^0.2.0"
 
@@ -247,10 +247,6 @@ ast-traverse@~0.1.1:
 ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
-
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
 
 ast-types@0.9.6:
   version "0.9.6"
@@ -527,12 +523,6 @@ babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.11:
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz#6c562bf561fccd406ce14ab04f42c218cf956605"
   dependencies:
     semver "^5.3.0"
-
-babel-plugin-ember-modules-api-polyfill@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.5.0.tgz#5ab880597d44118ee56c21d143f75f245efd4e95"
-  dependencies:
-    ember-rfc176-data "^0.2.0"
 
 babel-plugin-ember-modules-api-polyfill@^1.5.1:
   version "1.6.0"
@@ -1836,24 +1826,7 @@ ember-cli-babel@^5.1.6:
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0-beta.7:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.0.tgz#8f8d65e38439e4d343b701bcc0ac6ebd785a0e98"
-  dependencies:
-    amd-name-resolver "0.0.7"
-    babel-plugin-debug-macros "^0.1.11"
-    babel-plugin-ember-modules-api-polyfill "^1.5.0"
-    babel-plugin-transform-es2015-modules-amd "^6.24.0"
-    babel-polyfill "^6.16.0"
-    babel-preset-env "^1.5.1"
-    broccoli-babel-transpiler "^6.1.2"
-    broccoli-debug "^0.6.2"
-    broccoli-funnel "^1.0.0"
-    broccoli-source "^1.1.0"
-    clone "^2.0.0"
-    ember-cli-version-checker "^2.0.0"
-
-ember-cli-babel@^6.8.1:
+ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.8.1:
   version "6.8.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.1.tgz#695f94c57a9375c2a0e219306a41105d6b937991"
   dependencies:
@@ -2725,7 +2698,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.1.1:
+glob@7.1.1, glob@^7.0.4, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -2743,17 +2716,6 @@ glob@^5.0.10, glob@^5.0.15:
     inflight "^1.0.4"
     inherits "2"
     minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.4, glob@^7.0.5:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -3768,17 +3730,13 @@ minimatch@^2.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
@@ -4250,20 +4208,11 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"
@@ -4697,11 +4646,7 @@ spawn-sync@^1.0.15:
     concat-stream "^1.4.7"
     os-shim "^0.1.2"
 
-sprintf-js@^1.0.3:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
-
-sprintf-js@~1.0.2:
+sprintf-js@^1.0.3, sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 


### PR DESCRIPTION
This supports module unification namespaces by passing them in the lookup string. This an alternative to #215. Doing it this way reduces the number of changes required in ember.js and here as well.

A new version of glimmer-resolver has to be released in order for these tests to pass. Issue: https://github.com/glimmerjs/glimmer-resolver/issues/24

Examples:
 - If this resolver is called with `resolver.resolve('template:components/other-namespace::my-component')` it will pass `template:/other-namespace/components/my-component` to the glimmer resolver.
 - If this resolver is called with `resolver.resolve('service:/other-namespace/services/i18n')` it will pass `service:other-namespace::i18n` to the glimmer resolver.

See https://github.com/emberjs/ember.js/pull/15967 for results of end-to-end test. 

Related PRs:
 - https://github.com/glimmerjs/glimmer-resolver/pull/20
 - https://github.com/emberjs/ember.js/pull/15967