### PR TITLE
Glimmer Resolver gets target namespace as third argument

### DIFF
--- a/mu-trees/addon/resolvers/fallback/index.js
+++ b/mu-trees/addon/resolvers/fallback/index.js
@@ -9,8 +9,8 @@ export default Resolver.extend({
       namespace: { modulePrefix: this.config.app.name }
     }, options));
   },
-  resolve(name, referrer, rawString) {
-    let result = this._super(name, referrer, rawString);
+  resolve(name, referrer, targetNamespace) {
+    let result = this._super(name, referrer, targetNamespace);
     return result || this._fallback.resolve(name);
   }
 });

--- a/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
+++ b/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
@@ -801,3 +801,82 @@ test('Can resolve a namespaced component object', function(assert) {
     'namespaced resolution resolved'
   );
 });
+
+// Main addon component and service
+
+test('Can resolve a namespaced main service lookup', function(assert) {
+  let service = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      service: { definitiveCollection: 'services' }
+    },
+    collections: {
+      services: {
+        types: [ 'service' ]
+      }
+    }
+  }, {
+    'service:/other-namespace/services/main': service
+  });
+
+  assert.equal(
+    resolver.resolve('service:other-namespace', null),
+    service,
+    'namespaced resolution resolved'
+  );
+});
+
+test('Can resolve a namespaced main component template', function(assert) {
+  let template = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      template: { definitiveCollection: 'components' }
+    },
+    collections: {
+      components: {
+        group: 'ui',
+        types: [ 'template' ]
+      }
+    }
+  }, {
+    'template:/other-namespace/components/main': template
+  });
+
+  assert.equal(
+    resolver.resolve('template:components/other-namespace', null),
+    template,
+    'namespaced resolution resolved'
+  );
+});
+
+test('Can resolve a namespaced component object', function(assert) {
+  let component = {};
+  let resolver = this.resolverForEntries({
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      component: { definitiveCollection: 'components' }
+    },
+    collections: {
+      components: {
+        group: 'ui',
+        types: [ 'component' ]
+      }
+    }
+  }, {
+    'component:/other-namespace/components/main': component
+  });
+
+  assert.equal(
+    resolver.resolve('component:other-namespace', null),
+    component,
+    'namespaced resolution resolved'
+  );
+});

--- a/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
+++ b/mu-trees/tests/unit/resolvers/glimmer-wrapper/basic-test.js
@@ -744,7 +744,7 @@ test('Can resolve a namespaced service lookup', function(assert) {
   });
 
   assert.equal(
-    resolver.resolve('service', null, 'other-namespace::i18n'),
+    resolver.resolve('service:i18n', null, 'other-namespace'),
     service,
     'namespaced resolution resolved'
   );
@@ -770,7 +770,7 @@ test('Can resolve a namespaced component template', function(assert) {
   });
 
   assert.equal(
-    resolver.resolve('template:components/', null, 'other-namespace::my-component'),
+    resolver.resolve('template:components/my-component', null, 'other-namespace'),
     template,
     'namespaced resolution resolved'
   );
@@ -796,7 +796,7 @@ test('Can resolve a namespaced component object', function(assert) {
   });
 
   assert.equal(
-    resolver.resolve('component', null, 'other-namespace::my-component'),
+    resolver.resolve('component:my-component', null, 'other-namespace'),
     component,
     'namespaced resolution resolved'
   );


### PR DESCRIPTION
@mixonic @dgeb @rwjblue 
Replaces `rawString`. Amazingly I changed the tests first and they all past with no addon changes. However this change allows us to simplify the glimmer-wrapper so I did that as well. @mixonic please review and let me know if the tests reflect the interface that we discussed in the last Module Unification meeting.

I'd also like to clarify what the call to resolve should look like when fetching the main service or component for an addon. I added some tests and in this case we should not expect a namespace passed to the resolve since there will be no `::` in the lookup in Ember. So for example `resolve('component:power-select')` will currently find a component named `main` in the `power-select` addon, and `resolve('service:ember-data')` would find `/ember-data/src/services/main`.