### PR TITLE
Fix Main Service Lookup

### DIFF
--- a/mu-trees/addon/ember-config.js
+++ b/mu-trees/addon/ember-config.js
@@ -30,6 +30,7 @@ export default function generateConfig(name) {
       serializer: { definitiveCollection: 'models' },
       service: { definitiveCollection: 'services' },
       template: { definitiveCollection: 'components' },
+      'template-options': { definitiveCollection: 'main' },
       transform: { definitiveCollection: 'transforms' },
       view: { definitiveCollection: 'views' },
       '-view-registry': { definitiveCollection: 'main' },

--- a/mu-trees/addon/module-registries/requirejs.js
+++ b/mu-trees/addon/module-registries/requirejs.js
@@ -36,7 +36,7 @@ export default class RequireJSRegistry {
       segments.push(s.namespace);
     }
 
-    if (s.name !== 'main') {
+    if (s.name !== 'main' || s.collection !== 'main') {
       segments.push(s.name);
     }
 

--- a/mu-trees/tests/unit/module-registries/requirejs-test.js
+++ b/mu-trees/tests/unit/module-registries/requirejs-test.js
@@ -60,7 +60,7 @@ module('RequireJS Registry', {
 });
 
 test('basic get', function(assert) {
-  assert.expect(8);
+  assert.expect(11);
 
   [
     /*
@@ -74,7 +74,11 @@ test('basic get', function(assert) {
     [ 'template:/my-app/routes/components/my-input', 'my-app/src/ui/components/my-input/template' ],
     [ 'template:/my-app/components/my-input', 'my-app/src/ui/components/my-input/template' ],
     [ 'component:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/component' ],
-    [ 'template:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/template' ]
+    [ 'template:/my-app/components/my-input/my-button', 'my-app/src/ui/components/my-input/my-button/template' ],
+    [ 'service:/my-app/services/main', 'my-app/src/services/main' ],
+    [ 'component:/my-app/components/main', 'my-app/src/ui/components/main/component' ],
+    [ 'template:/my-app/components/main', 'my-app/src/ui/components/main/template' ],
+
   ]
   .forEach(([ lookupString, expected ]) => {
     let expectedModule = {};


### PR DESCRIPTION
@mixonic  @dgeb This PR fixes the RequireJS Registry for main services/components.

Previously we were ignoring the name 'main'. This was to avoid lookups with something like `/my-app/src/router/main/main`. However really we should ignore main if it is the name AND collection, and allow the name when the collection is something else.

This allows me to name the service "main" in the `mu-golden-spike` app.

I also added the `'template-options'` type to config since this seems to be a new thing in Ember.

Fixes https://github.com/glimmerjs/glimmer-resolver/issues/25