### PR TITLE
Normalize specifiers before passing to fallback

### DIFF
--- a/mu-trees/addon/resolvers/fallback/index.js
+++ b/mu-trees/addon/resolvers/fallback/index.js
@@ -11,6 +11,6 @@ export default Resolver.extend({
   },
   resolve(name, referrer, targetNamespace) {
     let result = this._super(name, referrer, targetNamespace);
-    return result || this._fallback.resolve(name);
+    return result || this._fallback.resolve(this._fallback.normalize(name));
   }
 });

--- a/mu-trees/tests/unit/resolvers/fallback/basic-test.js
+++ b/mu-trees/tests/unit/resolvers/fallback/basic-test.js
@@ -44,6 +44,14 @@ test('resolves from classic resolver', function(assert) {
   assert.equal(this.resolver.resolve('router:/app/main/classic', 'referrer'), this.classic, 'returns classic resolver result');
 });
 
+test('resolves normalized specifiers classic resolver', function(assert) {
+  this.resolver._fallback.resolve = (specifier) => {
+    return specifier === 'router:classic-router' ? this.classic : null;
+  };
+
+  assert.equal(this.resolver.resolve('router:classicRouter'), this.classic, 'returns classic resolver result');
+});
+
 test('returns null if neither resolver resolves', function(assert) {
   let specifier = 'router:/app/main/nowhere';
   let referrer = 'router:/app/main/referrer';


### PR DESCRIPTION
@mixonic 

Normalize specifiers before passing to fallback.

Without this change, apps that have a multiword service, for example:
```js
export default Component.extend({
  flashMessages: service()
})
```

Would have to change this to

```js
export default Component.extend({
  flashMessages: service('flash-messages')
})
```

Please remember to cut a new release once this is merged.