### PR TITLE
Added config type to module unification config

### DIFF
--- a/mu-trees/addon/ember-config.js
+++ b/mu-trees/addon/ember-config.js
@@ -14,6 +14,7 @@ export default function generateConfig(name) {
     types: {
       adapter: { definitiveCollection: 'models' },
       application: { definitiveCollection: 'main' },
+      config: { definitiveCollection: 'config' },
       controller: { definitiveCollection: 'routes' },
       component: { definitiveCollection: 'components' },
       'component-lookup': { definitiveCollection: 'main' },
@@ -46,6 +47,9 @@ export default function generateConfig(name) {
         group: 'ui',
         privateCollections: ['utils'],
         types: ['component', 'helper', 'template']
+      },
+      config: {
+        unresolvable: true
       },
       initializers: {
         group: 'init',


### PR DESCRIPTION
Yesterday I raised https://github.com/ember-fastboot/ember-cli-fastboot/issues/596, where a combination of using ember-cli-fastboot with module unification caused this error when running the server.

`Error: Assertion Failed: 'config' is not a recognized type`

@rwjblue suggested creating this PR to solve the issues of a missing type.

The changes I've made certainly solves the issue I had and my [module unification example app with fastboot](https://github.com/chrism/test-fastboot-mu) now renders.

Having said that I have no idea if my idea to create a `type` and `definitiveCollection` and then make that unresolvable (copied from ùtils`) is the correct solution with no unintended side-effects.