### PR TITLE
Fix MU for deeply nested classic components

### DIFF
--- a/mu-trees/addon/module-registries/requirejs.js
+++ b/mu-trees/addon/module-registries/requirejs.js
@@ -61,8 +61,8 @@ export default class RequireJSRegistry {
   }
 
   _checkDefaultType(specifier) {
-    let {defaultType} = this._config.collections[specifier.collection];
-    return defaultType && defaultType === specifier.type;
+    let collection = this._config.collections[specifier.collection];
+    return collection && collection.defaultType && collection.defaultType === specifier.type;
   }
 
   has(specifierString) {


### PR DESCRIPTION
In a MU app consuming a classic addon that exposes nested components, they seem to work as long there is just one "layer" below, like `components/foo/bar.js`, but not for deeper layered components, like `components/foo/bar/baz.js`. This fails when resolving, it somehow thinks `bar` is a collection, and tries to get the default type from undefined. This throws in the place I changed here, so before the fallback is even tried.