### PR TITLE
fix(glimmer-wrapper): move debug `normalize` in `.extend()` block

### DIFF
--- a/mu-trees/addon/resolvers/glimmer-wrapper/index.js
+++ b/mu-trees/addon/resolvers/glimmer-wrapper/index.js
@@ -82,7 +82,15 @@ const Resolver = GlobalsResolver.extend({
     this._glimmerResolver = new GlimmerResolver(this.config, this.glimmerModuleRegistry);
   },
 
-  normalize: null,
+  normalize: !DEBUG ? null : function(specifier) {
+    // This method is called by `Registry#validateInjections` in dev mode.
+    // https://github.com/ember-cli/ember-resolver/issues/299
+    const [type, name] = specifier.split(':', 2);
+    if (name && (type === 'service' || type === 'controller')) {
+      return `${type}:${dasherize(name)}`;
+    }
+    return specifier;
+  },
 
   expandLocalLookup(specifier, source, namespace) {
     if (isAbsoluteSpecifier(specifier)) {
@@ -139,17 +147,5 @@ const Resolver = GlobalsResolver.extend({
   }
 
 });
-
-if (DEBUG) {
-  Resolver.prototype.normalize = function(specifier) {
-    // This method is called by `Registry#validateInjections` in dev mode.
-    // https://github.com/ember-cli/ember-resolver/issues/299
-    const [type, name] = specifier.split(':', 2);
-    if (name && (type === 'service' || type === 'controller')) {
-      return `${type}:${dasherize(name)}`;
-    }
-    return specifier;
-  }
-}
 
 export default Resolver;

--- a/mu-trees/addon/resolvers/glimmer-wrapper/index.js
+++ b/mu-trees/addon/resolvers/glimmer-wrapper/index.js
@@ -64,6 +64,16 @@ function cleanupEmberSpecifier(specifier, source, _namespace) {
   return [specifier, source];
 }
 
+const normalize = !DEBUG ? null : function (specifier) {
+  // This method is called by `Registry#validateInjections` in dev mode.
+  // https://github.com/ember-cli/ember-resolver/issues/299
+  const [type, name] = specifier.split(':', 2);
+  if (name && (type === 'service' || type === 'controller')) {
+    return `${type}:${dasherize(name)}`;
+  }
+  return specifier;
+};
+
 /*
  * Wrap the @glimmer/resolver in Ember's resolver API. Although
  * this code extends from the DefaultResolver, it should never
@@ -82,15 +92,7 @@ const Resolver = GlobalsResolver.extend({
     this._glimmerResolver = new GlimmerResolver(this.config, this.glimmerModuleRegistry);
   },
 
-  normalize: !DEBUG ? null : function(specifier) {
-    // This method is called by `Registry#validateInjections` in dev mode.
-    // https://github.com/ember-cli/ember-resolver/issues/299
-    const [type, name] = specifier.split(':', 2);
-    if (name && (type === 'service' || type === 'controller')) {
-      return `${type}:${dasherize(name)}`;
-    }
-    return specifier;
-  },
+  normalize,
 
   expandLocalLookup(specifier, source, namespace) {
     if (isAbsoluteSpecifier(specifier)) {

--- a/mu-trees/addon/resolvers/glimmer-wrapper/index.js
+++ b/mu-trees/addon/resolvers/glimmer-wrapper/index.js
@@ -64,7 +64,7 @@ function cleanupEmberSpecifier(specifier, source, _namespace) {
   return [specifier, source];
 }
 
-const normalize = !DEBUG ? null : function (specifier) {
+const normalize = !DEBUG ? null : function(specifier) {
   // This method is called by `Registry#validateInjections` in dev mode.
   // https://github.com/ember-cli/ember-resolver/issues/299
   const [type, name] = specifier.split(':', 2);


### PR DESCRIPTION
https://github.com/ember-cli/ember-resolver/pull/300#issuecomment-452696317

> This seems to be broken. `Resolver#normalize` is `null` even though the following is included in the build:
> 
> ```js
>   if (true) {
>     Resolver.prototype.normalize = function (specifier) {
>       // This method is called by `Registry#validateInjections` in dev mode.
>       // https://github.com/ember-cli/ember-resolver/issues/299
>       const [type, name] = specifier.split(':', 2);
>       if (name && (type === 'service' || type === 'controller')) {
>         return `${type}:${Ember.String.dasherize(name)}`;
>       }
>       return specifier;
>     };
>   }
> ```
> 
> I assume that this is because Ember manually collapses the prototype and `normalize: null` somehow takes precedence.
> 
> What is your suggested solution? Use `.reopen({ ... })` or use a ternary in the original `.extend({ ... })` block? I'm leaning towards a ternary like:
> 
> ```js
> const Resolver = GlobalsResolver.extend({
>   // ...
> 
>   normalize: !DEBUG ? null : function(specifier) {
>     // This method is called by `Registry#validateInjections` in dev mode.
>     // https://github.com/ember-cli/ember-resolver/issues/299
>     const [type, name] = specifier.split(':', 2);
>     if (name && (type === 'service' || type === 'controller')) {
>       return `${type}:${dasherize(name)}`;
>     }
>     return specifier;
>   },
> 
>   // ...
> });
> ```
> 
> I assume constant ternaries are also optimized away by `ember-cli-uglify` / [`terser`](https://github.com/terser-js/terser)?

