### PR TITLE
Support engine resolution in scoped packages

### DIFF
--- a/addon/resolvers/classic/index.js
+++ b/addon/resolvers/classic/index.js
@@ -45,17 +45,18 @@ function parseName(fullName) {
   let prefix, type, name;
   let fullNameParts = fullName.split('@');
 
-  // HTMLBars uses helper:@content-helper which collides
-  // with ember-cli namespace detection.
-  // This will be removed in a future release of HTMLBars.
-  if (fullName !== 'helper:@content-helper' &&
-      fullNameParts.length === 2) {
+  if (fullNameParts.length === 2) {
     let prefixParts = fullNameParts[0].split(':');
 
     if (prefixParts.length === 2) {
-      prefix = prefixParts[1];
-      type = prefixParts[0];
-      name = fullNameParts[1];
+      if (prefixParts[1].length === 0) {
+        type = prefixParts[0];
+        name = `@${fullNameParts[1]}`;
+      } else {
+        prefix = prefixParts[1];
+        type = prefixParts[0];
+        name = fullNameParts[1];
+      }
     } else {
       let nameParts = fullNameParts[1].split(':');
 

--- a/tests/unit/resolvers/classic/basic-test.js
+++ b/tests/unit/resolvers/classic/basic-test.js
@@ -206,6 +206,22 @@ test('can lookup an engine', function(assert) {
   assert.equal(engine, expected, 'default export was returned');
 });
 
+test('can lookup an engine from a scoped package', function(assert) {
+  assert.expect(3);
+
+  let expected = {};
+  define('@some-scope/some-module/engine', [], function(){
+    assert.ok(true, "engine was invoked properly");
+
+    return { default: expected };
+  });
+
+  var engine = resolver.resolve('engine:@some-scope/some-module');
+
+  assert.ok(engine, 'engine was returned');
+  assert.equal(engine, expected, 'default export was returned');
+});
+
 test('can lookup a route-map', function(assert) {
   assert.expect(3);
 


### PR DESCRIPTION
I _think_ this accomplishes the same thing as #270, but without the switch to regex matching and associated perf concerns. It also allows the removal of the `helper:@content-helper` special case (the associated test still passes).

Does this seem like a reasonable alternative to the approach in #270?

/cc @buschtoens @rwjblue 

Closes #270 