### PR TITLE
refactor: Move a once-used local into use-scope

### DIFF
--- a/mu-trees/addon/resolvers/glimmer-wrapper/index.js
+++ b/mu-trees/addon/resolvers/glimmer-wrapper/index.js
@@ -102,13 +102,13 @@ const Resolver = GlobalsResolver.extend({
     if (source || namespace) {
       let rootName = namespace || this._configRootName;
 
-      let [type] = specifier.split(':');
-
       /*
        * Ember components require their lookupString to be massaged. Make this
        * as "pay-go" as possible.
        */
       if (namespace) {
+        let [type] = specifier.split(':', 2);
+
         // This is only required because:
         // https://github.com/glimmerjs/glimmer-di/issues/45
         source = `${type}:/${rootName}/`;


### PR DESCRIPTION
This PR is a refactoring, but really, it's just "changing code", since I was not able to have the mu-trees tests fail, or even to run?

This change:

  - A string is `split` into 2 groups only - we use only the first element
  - The variable `let` is moved into a scope where it's used