### PR TITLE
Fix MU `GlimmerResolver.normalize` when `fullName` is not present

### DIFF
--- a/mu-trees/addon/resolvers/glimmer-wrapper/index.js
+++ b/mu-trees/addon/resolvers/glimmer-wrapper/index.js
@@ -63,15 +63,16 @@ function cleanupEmberSpecifier(specifier, source, _namespace) {
 
   return [specifier, source];
 }
-
-const normalize = !DEBUG ? null : function(specifier) {
+const normalize = !DEBUG ? null : function(fullName) {
   // This method is called by `Registry#validateInjections` in dev mode.
   // https://github.com/ember-cli/ember-resolver/issues/299
-  const [type, name] = specifier.split(':', 2);
-  if (name && (type === 'service' || type === 'controller')) {
-    return `${type}:${dasherize(name)}`;
+  if (fullName) {
+    const [type, name] = fullName.split(':', 2);
+    if (name && (type === 'service' || type === 'controller')) {
+      return `${type}:${dasherize(name)}`;
+    }
   }
-  return specifier;
+  return fullName;
 };
 
 /*

--- a/mu-trees/tests/unit/resolvers/glimmer-wrapper/normalize-test.js
+++ b/mu-trees/tests/unit/resolvers/glimmer-wrapper/normalize-test.js
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import Resolver from 'ember-resolver/resolvers/glimmer-wrapper';
+import BasicRegistry from '@glimmer/resolver/module-registries/basic-registry';
+
+let resolver;
+module('ember-resolver/resolvers/glimmer-wrapper#normalize', {
+  beforeEach() {
+
+    let glimmerModuleRegistry = new BasicRegistry();
+
+    resolver = Resolver.create({
+      config: {
+        app: {
+          name: 'example-app'
+        }
+      },
+      glimmerModuleRegistry
+    });
+  }
+});
+
+test('normalization', function(assert) {
+  assert.ok(resolver.normalize, 'resolver#normalize is present');
+
+  assert.equal(resolver.normalize('service:myService'), 'service:my-service');
+
+  // `expandLocalLookup` calls this.normalize(options.source) with `source` empty with MU addon
+  assert.equal(resolver.normalize(), undefined);
+
+});


### PR DESCRIPTION
This error is triggered when injecting an MU addon service like:

```
export default class ApplicationController extends Controller {
  @service('my-addon::hola') hola
}
```

The change checks that `fullName` is not empty to avoid triggering the error. The error is triggered when the registry calls `normalize` at https://github.com/emberjs/ember.js/blob/master/packages/%40ember/-internals/container/lib/registry.ts#L690:

In this case, `options.source` will be null, but `options.namespace` is `my-addon`.

```
      let normalizedFullName = this.normalize(fullName);
      let normalizedSource = this.normalize(options.source!);
```

This fix makes that the service can be resolved correctly.

I also wonder if the current implementation of the MU `Glimmer.resolve` may not cover all the possible cases, because the [GlobalsResolver.resolve](https://github.com/emberjs/ember.js/blob/v3.8.0/packages/%40ember/application/globals-resolver.js#L103) and [ClassicResolver.resolve](https://github.com/ember-cli/ember-resolver/blob/master/addon/resolvers/classic/index.js#L166) look different. (Note: I am not familiar with this code).


cc @rwjblue 




