### PR TITLE
Component and their templates should be normalized the same.

### DIFF
--- a/addon/resolvers/classic/index.js
+++ b/addon/resolvers/classic/index.js
@@ -165,7 +165,9 @@ const Resolver = EmberObject.extend({
 
   _normalize(fullName) {
     // A) Convert underscores to dashes
-    // B) Convert camelCase to dash-case, except for components and helpers where we want to avoid shadowing camelCase expressions
+    // B) Convert camelCase to dash-case, except for components (their
+    //    templates) and helpers where we want to avoid shadowing camelCase
+    //    expressions
     // C) replace `.` with `/` in order to make nested controllers work in the following cases
     //      1. `needs: ['posts/post']`
     //      2. `{{render "posts/post"}}`
@@ -173,10 +175,16 @@ const Resolver = EmberObject.extend({
 
     let split = fullName.split(':');
     if (split.length > 1) {
-      if (split[0] === 'component' || split[0] === 'helper') {
-        return split[0] + ':' + split[1].replace(/_/g, '-');
+      let type = split[0];
+
+      if (
+        type === 'component' ||
+        type === 'helper' ||
+        (type === 'template' && split[1].indexOf('components/') === 0)
+      ) {
+        return type + ':' + split[1].replace(/_/g, '-');
       } else {
-        return split[0] + ':' + dasherize(split[1].replace(/\./g, '/'));
+        return type + ':' + dasherize(split[1].replace(/\./g, '/'));
       }
     } else {
       return fullName;

--- a/tests/unit/resolvers/classic/basic-test.js
+++ b/tests/unit/resolvers/classic/basic-test.js
@@ -462,6 +462,7 @@ test('normalization', function(assert) {
   // The same applies to components
   assert.equal(resolver.normalize('component:fabulous-component'), 'component:fabulous-component');
   assert.equal(resolver.normalize('component:fabulousComponent'), 'component:fabulousComponent');
+  assert.equal(resolver.normalize('template:components/fabulousComponent'), 'template:components/fabulousComponent');
 });
 
 test('normalization is idempotent', function(assert) {


### PR DESCRIPTION
The changes that landed in 35890e05 ensured that a component itself is not normalized, but it did not account for components templates. The result was that a given `{{fooBar}}` in a template would not find a `foo-bar` components JS file, but it would find its template.

Fixes https://github.com/emberjs/ember.js/issues/18231