### PR TITLE
Fix babel-plugin-debug-macros warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,37 +13,6 @@ module.exports = {
     }, resolverConfig.features);
   },
 
-  init() {
-    this._super.init.apply(this, arguments);
-    this.options = this.options || {};
-    if (process.env.EMBER_CLI_MODULE_UNIFICATION) {
-      this.project.isModuleUnification = function () {
-        return true;
-      }
-    }
-    this._emberResolverFeatureFlags = this.emberResolverFeatureFlags();
-
-    this.options.babel = {
-      loose: true,
-      plugins: [
-        [require.resolve('babel-plugin-debug-macros'), {
-          debugTools: {
-            source: 'this-is-dumb-it-should-not-be-required-i-blame-rwjblue'
-          },
-          envFlags: {
-            source: 'ember-resolver-env-flags',
-            flags: { DEBUG: process.env.EMBER_ENV != 'production' }
-          },
-          features: {
-            name: 'ember-resolver',
-            source: 'ember-resolver/features',
-            flags: this._emberResolverFeatureFlags
-          }
-        }]
-      ]
-    };
-  },
-
   included() {
     this._super.included.apply(this, arguments);
 


### PR DESCRIPTION
Some Module Unification configuration remained in `init` of `index.js`
which happened to be using the older v1 babel-plugin-debug-macros
configuration API, resulting in many spurious and inactionable warnings
to the console, eg

```
building...
babel-plugin-debug-macros configuration API has changed, please update your configuration
babel-plugin-debug-macros configuration API has changed, please update your configuration
babel-plugin-debug-macros configuration API has changed, please update your configuration
babel-plugin-debug-macros configuration API has changed, please update your configuration
babel-plugin-debug-macros configuration API has changed, please update your configuration
babel-plugin-debug-macros configuration API has changed, please update your configuration
babel-plugin-debug-macros configuration API has changed, please update your configuration
cleaning up
```

Kill it, and in so doing, kill the warning.
