### PR TITLE
failing test for looking up in namespace contains a @ sign in module prefix

### DIFF
--- a/tests/unit/resolvers/classic/basic-test.js
+++ b/tests/unit/resolvers/classic/basic-test.js
@@ -111,6 +111,20 @@ test("can lookup something in another namespace with different syntax", function
   assert.equal(adapter, expected, 'default export was returned');
 });
 
+test("can lookup something in another namespace contains a @ sign in module prefix", function(assert) {
+  let expected = {};
+
+  define('@scope/other/components/foo-bar', [], function() {
+    assert.ok(true, "component was invoked properly");
+    return { default: expected }
+  })
+
+  const component = resolver.resolve('component:@scope/other@component:foo-bar');
+
+  assert.ok(component, 'component was returned');
+  assert.equal(component, expected, 'default export was returned');
+});
+
 test("can lookup a view in another namespace", function(assert) {
   assert.expect(3);
 


### PR DESCRIPTION
This previously failing test case is for addressing an issue that discussed in discord:

https://discordapp.com/channels/480462759797063690/491905849405472769/682777856446824466

which in short, it is impossible for now to invoke a component from a namespace contains a `@` sign in its `modulePrefix`.

For example, I have an ember add-on that will be published as `@org/ui-kit`. For naming consistency purposes, I set its `modulePrefix` to `"@org/ui-kit"` as well.

However, I can not invoke components in this add-on from any consuming application in this form:

```htmlbars
<@org/UiKit@Forms::Input />
```

Although this PR revealed this issue, I still in doubt personally that this form of invocation is a good idea. People can change the `modulePrefix` easily to:

```htmlbars
<OrgUiKit@Forms::Input />
```

or re-export it as normal ember add-ons did.