### PR TITLE
fix: resolving `@scope/name` namespaces

### DIFF
--- a/addon/resolvers/classic/index.js
+++ b/addon/resolvers/classic/index.js
@@ -44,7 +44,25 @@ function parseName(fullName) {
   let prefix, type, name;
   let fullNameParts = fullName.split('@');
 
-  if (fullNameParts.length === 2) {
+  if (fullNameParts.length === 3) {
+    if (fullNameParts[0].length === 0) {
+      // leading scoped namespace: `@scope/pkg@type:name`
+      prefix = `@${fullNameParts[1]}`;
+      let prefixParts = fullNameParts[2].split(':');
+      type = prefixParts[0];
+      name = prefixParts[1];
+    } else {
+      // interweaved scoped namespace: `type:@scope/pkg@name`
+      prefix = `@${fullNameParts[1]}`;
+      type = fullNameParts[0].slice(0, -1);
+      name = fullNameParts[2];
+    }
+
+    if (type === 'template:components') {
+      name = `components/${name}`;
+      type = 'template';
+    }
+  } else if (fullNameParts.length === 2) {
     let prefixParts = fullNameParts[0].split(':');
 
     if (prefixParts.length === 2) {

--- a/tests/unit/resolvers/classic/basic-test.js
+++ b/tests/unit/resolvers/classic/basic-test.js
@@ -79,6 +79,25 @@ test("can lookup something in another namespace", function(assert){
   assert.equal(adapter, expected, 'default export was returned');
 });
 
+test("can lookup something in another namespace with an @ scope", function(assert){
+  assert.expect(3);
+
+  let expected = {};
+
+  define('@scope/other/adapters/post', [], function(){
+    assert.ok(true, "adapter was invoked properly");
+
+    return {
+      default: expected
+    };
+  });
+
+  var adapter = resolver.resolve('@scope/other@adapter:post');
+
+  assert.ok(adapter, 'adapter was returned');
+  assert.equal(adapter, expected, 'default export was returned');
+});
+
 test("can lookup something with an @ sign", function(assert){
   assert.expect(3);
 
@@ -111,6 +130,22 @@ test("can lookup something in another namespace with different syntax", function
   assert.equal(adapter, expected, 'default export was returned');
 });
 
+test("can lookup something in another namespace with an @ scope with different syntax", function(assert){
+  assert.expect(3);
+
+  let expected = {};
+  define('@scope/other/adapters/post', [], function(){
+    assert.ok(true, "adapter was invoked properly");
+
+    return { default: expected };
+  });
+
+  var adapter = resolver.resolve('adapter:@scope/other@post');
+
+  assert.ok(adapter, 'adapter was returned');
+  assert.equal(adapter, expected, 'default export was returned');
+});
+
 test("can lookup a view in another namespace", function(assert) {
   assert.expect(3);
 
@@ -122,6 +157,22 @@ test("can lookup a view in another namespace", function(assert) {
   });
 
   var view = resolver.resolve('other@view:post');
+
+  assert.ok(view, 'view was returned');
+  assert.equal(view, expected, 'default export was returned');
+});
+
+test("can lookup a view in another namespace with an @ scope", function(assert) {
+  assert.expect(3);
+
+  let expected = { isViewFactory: true };
+  define('@scope/other/views/post', [], function(){
+    assert.ok(true, "view was invoked properly");
+
+    return { default: expected };
+  });
+
+  var view = resolver.resolve('@scope/other@view:post');
 
   assert.ok(view, 'view was returned');
   assert.equal(view, expected, 'default export was returned');
@@ -143,6 +194,22 @@ test("can lookup a view in another namespace with different syntax", function(as
   assert.equal(view, expected, 'default export was returned');
 });
 
+test("can lookup a view in another namespace with an @ scope with different syntax", function(assert) {
+  assert.expect(3);
+
+  let expected = { isViewFactory: true };
+  define('@scope/other/views/post', [], function(){
+    assert.ok(true, "view was invoked properly");
+
+    return { default: expected };
+  });
+
+  var view = resolver.resolve('view:@scope/other@post');
+
+  assert.ok(view, 'view was returned');
+  assert.equal(view, expected, 'default export was returned');
+});
+
 test("can lookup a component template in another namespace with different syntax", function(assert) {
   assert.expect(2);
 
@@ -154,6 +221,21 @@ test("can lookup a component template in another namespace with different syntax
   });
 
   var template = resolver.resolve('template:components/other@foo-bar');
+
+  assert.equal(template, expected, 'default export was returned');
+});
+
+test("can lookup a component template in another namespace with an @ scope with different syntax", function(assert) {
+  assert.expect(2);
+
+  let expected = { isTemplate: true };
+  define('@scope/other/templates/components/foo-bar', [], function(){
+    assert.ok(true, "template was looked up properly");
+
+    return { default: expected };
+  });
+
+  var template = resolver.resolve('template:components/@scope/other@foo-bar');
 
   assert.equal(template, expected, 'default export was returned');
 });


### PR DESCRIPTION
It is possible resolve modules from other packages using namespaces. For instance, the following looks up the `intl` service _directly_ from the `ember-intl` package:

```ts
this.owner.lookup('ember-intl@service:intl');
this.owner.lookup('service:ember-intl@intl');
```

Notably, this instance is `!==` to the `app` re-export that is merged with the host app:

```ts
this.owner.lookup('service:intl');
```

This is expected behavior.

So generalizing, the pattern for looking up something from a foreign package is:

```ts
this.owner.lookup(`${packageName}@{type}:${name}`);
this.owner.lookup(`{type}:${packageName}@${name}`);
```

Unfortunately, this _does not work_ for packages that have a [scoped name](https://docs.npmjs.com/using-npm/scope.html), e.g. `@corp/fancy-addon`.

The invocation would look like:

```ts
this.owner.lookup('@corp/fancy-addon@service:intl');
this.owner.lookup('service:@corp/fancy-addon@intl');
```

[`parseName(fullNane)`](https://github.com/ember-cli/ember-resolver/blob/59d6e19cfd19c8f16f6f1cada771112da6231b9a/addon/resolvers/classic/index.js#L41-L91) does not support this, as it was written before package scopes were introduced and only expected a single `@` to be present.

https://github.com/ember-cli/ember-resolver/blob/59d6e19cfd19c8f16f6f1cada771112da6231b9a/addon/resolvers/classic/index.js#L41-L91

This PR, so far, adds failing tests for scoped package names.

Is this something that we would want to fix? I personally have an interest in it and would finish the PR, if so.

#### Related

- [RFC 585: Registry APIs: deprecate micro-syntax; introduce replacement API](https://github.com/emberjs/rfcs/pull/585)
- #269