### PR TITLE
Remove automatic dasherization of modifiers.

### DIFF
--- a/addon/resolvers/classic/index.js
+++ b/addon/resolvers/classic/index.js
@@ -197,6 +197,7 @@ const Resolver = EmberObject.extend({
       if (
         type === 'component' ||
         type === 'helper' ||
+        type === 'modifier' ||
         (type === 'template' && split[1].indexOf('components/') === 0)
       ) {
         return type + ':' + split[1].replace(/_/g, '-');

--- a/tests/unit/resolvers/classic/basic-test.js
+++ b/tests/unit/resolvers/classic/basic-test.js
@@ -545,6 +545,34 @@ test('normalization', function(assert) {
   assert.equal(resolver.normalize('component:fabulous-component'), 'component:fabulous-component');
   assert.equal(resolver.normalize('component:fabulousComponent'), 'component:fabulousComponent');
   assert.equal(resolver.normalize('template:components/fabulousComponent'), 'template:components/fabulousComponent');
+
+  // and modifiers
+  assert.equal(resolver.normalize('modifier:fabulous-component'), 'modifier:fabulous-component');
+
+  // deprecated when fabulously-missing actually exists, but normalize still returns it
+  assert.equal(resolver.normalize('modifier:fabulouslyMissing'), 'modifier:fabulouslyMissing');
+});
+
+test('camel case modifier is not normalized', function(assert) {
+  assert.expect(2);
+
+  let expected = { };
+  define('appkit/modifiers/other-thing', [], function(){
+    assert.ok(false, 'appkit/modifiers/other-thing was accessed');
+
+    return { default: 'oh no' };
+  });
+
+  define('appkit/modifiers/otherThing', [], function(){
+    assert.ok(true, 'appkit/modifiers/otherThing was accessed');
+
+    return { default: expected };
+  });
+
+
+  let modifier = resolver.resolve('modifier:otherThing');
+
+  assert.strictEqual(modifier, expected);
 });
 
 test('normalization is idempotent', function(assert) {


### PR DESCRIPTION
Modifiers (like helpers and components) should not get automatically dasherized when looked up. Using `{{fooBar}}` and `{{foo-bar}}` interchangably to mean a given modifier is **very** confusing behavior, and was never intended. Unfortunately, when user land modifiers were added to Ember we forgot to update this guard to prevent dasherization.

Fixes https://github.com/ember-cli/ember-resolver/issues/506