### PR TITLE
Revert "Ensure app/foo/index.js can be looked up with foo:main"

### DIFF
--- a/addon/resolvers/classic/index.js
+++ b/addon/resolvers/classic/index.js
@@ -19,7 +19,7 @@ export class ModuleRegistry {
     return Object.keys(this._entries);
   }
   has(moduleName) {
-    return require.has(moduleName);
+    return moduleName in this._entries;
   }
   get(moduleName) {
     return require(moduleName);

--- a/tests/unit/resolvers/classic/basic-test.js
+++ b/tests/unit/resolvers/classic/basic-test.js
@@ -386,17 +386,6 @@ test("store:main is looked up as prefix/store", function(assert) {
   resolver.resolve('store:main');
 });
 
-test("store:main is looked up as prefix/store/index.js", function(assert) {
-  assert.expect(1);
-
-  define('appkit/store/index', [], function(){
-    assert.ok(true, 'store:main was looked up');
-    return 'whatever';
-  });
-
-  resolver.resolve('store:main');
-});
-
 test("store:posts as prefix/stores/post", function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
This reverts commit 9fae5ba1c5df7ce14fdfb6afc57ac8e2481b647b as it has reported that it breaks some normal lookup patterns (#589).

I'd still like to bring back this change, but we'll need to investigate the reported issues and figure out how to mitigate.

Fixes https://github.com/ember-cli/ember-resolver/issues/589