### PR TITLE
enable currently remaining ember-try scenarios

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -75,12 +75,12 @@ jobs:
           - ember-lts-3.20
           - ember-lts-3.24
           - ember-release
-          # - ember-beta
-          # - ember-canary
+          - ember-beta
+          - ember-canary
           - ember-classic
           - ember-default-with-jquery
-          # - embroider-safe
-          # - embroider-optimized
+          - embroider-safe
+          - embroider-optimized
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -79,8 +79,8 @@ jobs:
           - ember-canary
           - ember-classic
           - ember-default-with-jquery
-          - embroider-safe
-          - embroider-optimized
+          # - embroider-safe
+          # - embroider-optimized
 
     steps:
       - uses: actions/checkout@v2

--- a/addon/resolvers/classic/container-debug-adapter.js
+++ b/addon/resolvers/classic/container-debug-adapter.js
@@ -1,6 +1,7 @@
 import { A } from '@ember/array';
 import ContainerDebugAdapter from '@ember/debug/container-debug-adapter';
 import { ModuleRegistry } from './index';
+import { getOwner } from '@ember/application';
 
 function getPod(type, key, prefix) {
   let match = key.match(new RegExp('^/?' + prefix + '/(.+)/' + type + '$'));
@@ -19,6 +20,7 @@ export default ContainerDebugAdapter.extend({
 
   init() {
     this._super(...arguments);
+    this.namespace = getOwner(this).lookup('application:main');
 
     if (!this._moduleRegistry) {
       this._moduleRegistry = new ModuleRegistry();

--- a/addon/resolvers/classic/index.js
+++ b/addon/resolvers/classic/index.js
@@ -364,7 +364,12 @@ const Resolver = EmberObject.extend({
       'Attempted to lookup "'+moduleName+'" which ' +
       'was not found. Please rename "'+partializedModuleName+'" '+
       'to "'+moduleName+'" instead.', false,
-      { id: 'ember-resolver.underscored-modules', until: '3.0.0' });
+      {
+        id: 'ember-resolver.underscored-modules',
+        until: '3.0.0',
+        for: 'ember-resolver',
+        since: '0.1.0'
+      });
 
       return partializedModuleName;
     }

--- a/app/initializers/container-debug-adapter.js
+++ b/app/initializers/container-debug-adapter.js
@@ -7,6 +7,5 @@ export default {
     let app = arguments[1] || arguments[0];
 
     app.register('container-debug-adapter:main', ContainerDebugAdapter);
-    app.inject('container-debug-adapter:main', 'namespace', 'application:main');
   }
 };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@ember/test-helpers": "^2.2.5",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1",
     "ember-cli": "~3.27.0",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-htmlbars": "^5.7.1",
@@ -55,20 +56,20 @@
     "ember-qunit": "^5.1.4",
     "ember-source": "3.27.2",
     "ember-source-channel-url": "^3.0.0",
+    "ember-template-lint": "^3.4.2",
     "ember-try": "^1.4.0",
     "eslint": "^7.32.0",
-    "ember-template-lint": "^3.4.2",
     "eslint-plugin-ember": "^7.8.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-qunit": "^6.1.1",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
+    "prettier": "^2.3.0",
+    "qunit": "^2.17.1",
     "qunit-dom": "^1.6.0",
     "release-it": "^14.10.1",
-    "release-it-lerna-changelog": "^3.1.0",
-    "prettier": "^2.3.0",
-    "qunit": "^2.15.0"
+    "release-it-lerna-changelog": "^3.1.0"
   },
   "engines": {
     "node": ">= 10.*"

--- a/tests/unit/resolvers/classic/basic-test.js
+++ b/tests/unit/resolvers/classic/basic-test.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-console */
 
 import Ember from 'ember';
-import { merge } from '@ember/polyfills';
+import { assign } from '@ember/polyfills';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver/resolvers/classic';
 
@@ -18,12 +18,12 @@ function setupResolver(options = {}) {
 
 function resetRegistry() {
   requirejs.clear();
-  merge(requirejs.entries, originalRegistryEntries);
+  assign(requirejs.entries, originalRegistryEntries);
 }
 
 module('ember-resolver/resolvers/classic', {
   beforeEach() {
-    originalRegistryEntries = merge({}, requirejs.entries);
+    originalRegistryEntries = assign({}, requirejs.entries);
     originalConsoleInfo = console ? console.info : null;
 
     setupResolver();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4301,7 +4301,7 @@ elliptic@^6.5.3:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-auto-import@^1.10.1:
+ember-auto-import@^1, ember-auto-import@^1.10.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.12.0.tgz#52246b04891090e2608244e65c4c6af7710df12b"
   integrity sha512-fzMGnyHGfUNFHchpLbJ98Vs/c5H2wZBMR9r/XwW+WOWPisZDGLUPPyhJQsSREPoUQ+o8GvyLaD/rkrKqW8bmgw==
@@ -9395,10 +9395,10 @@ qunit-dom@^1.6.0:
     ember-cli-babel "^7.23.0"
     ember-cli-version-checker "^5.1.1"
 
-qunit@^2.15.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.17.0.tgz#4c2dd5a4ee91cd8f8462708a37e710a3e622c321"
-  integrity sha512-3zXO4T3KT8liCXYDqu68SmK6D7JgI80R6gUPGjzxXwh9rjwdmmx09YZhGLfT466PC/XlORr8xvxlNx3i3S72Rw==
+qunit@^2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.17.1.tgz#1969efe4c9b776b4b8cd4fc2fb9634e8f762e177"
+  integrity sha512-Gx1tpSfYbjRe4TRKCVBLlnCaVThF5Pdnmbbv/zLFfgWKddeQHV/eNi1BG392hw4gEDh2sflMj8kmPJlT7+kVMA==
   dependencies:
     commander "7.1.0"
     node-watch "0.7.1"


### PR DESCRIPTION
failures:

for ember-beta & ember-canary

* [x] namespace is missing on the `ContainerDebugAdapter` (needs debugging)
```
not ok 2 Chrome 92.0 - [2 ms] - Container Debug Adapter Tests: the default ContainerDebugAdapter catalogs controller entries
    ---
        actual: >
            null
        stack: >
            TypeError: Cannot read property 'modulePrefix' of undefined
                at Class.catalogEntriesByType (http://localhost:7357/assets/vendor.js:67503:35)
                at Object.<anonymous> (http://localhost:7357/assets/tests.js:88:45)
 ```
 
 * [x]  ember polyfils has removed `merge` 
 
 ```
 not ok 9 Chrome 92.0 - [0 ms] - ember-resolver/resolvers/classic: can lookup something in another namespace
    ---
        actual: >
            null
        stack: >
            TypeError: (0 , _polyfills.merge) is not a function
                at Object.beforeEach (http://localhost:7357/assets/tests.js:153:54)
        message: >
            beforeEach failed on can lookup something in another namespace: (0 , _polyfills.merge) is not a function
        negative: >
            false
        browser log: |
        
```


- [x]  deprecate is missing a for identifier



For embroider tests:

* [ ] inline module `define` are being re-written by embroider confusing the test. Maybe we can use a noconflict loader instead.

```
not ok 2 Chrome 92.0 - [1 ms] - TestLoader Failures: dummy/tests/unit/exports-test: could not be loaded
    ---
        actual: >
            null
        stack: >
            TypeError: (0 , _externals_qunit__WEBPACK_IMPORTED_MODULE_0__.module) is not a function
                at eval (webpack://dummy/./tests/unit/exports-test.js?:10:57)
                at Object../tests/unit/exports-test.js (http://localhost:7357/assets/chunk.6024f09b703bdf0ca33a.js:51:1)
                at __webpack_require__ (http://localhost:7357/assets/chunk.6024f09b703bdf0ca33a.js:96:41)
                at Module.eval [as callback] (webpack://dummy/./assets/test.js?:190:10)
                at Module.exports (http://localhost:7357/assets/vendor.js:112:32)
                at requireModule (http://localhost:7357/assets/vendor.js:33:18)
                at TestLoader.eval (webpack://dummy/../../node_modules/ember-cli-test-loader/test-support/index.js?:95:16)
                at TestLoader.require (webpack://dummy/../../node_modules/ember-cli-test-loader/test-support/index.js?:85:25)
                at TestLoader.loadModules (webpack://dummy/../../node_modules/ember-cli-test-loader/test-support/index.js?:76:14)
                at loadTests (webpack://dummy/../../node_modules/ember-qunit/test-loader.js?:88:20)
                
```
