### PR TITLE
enable embroider scenarios

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -79,8 +79,8 @@ jobs:
           - ember-canary
           - ember-classic
           - ember-default-with-jquery
-          # - embroider-safe
-          # - embroider-optimized
+          - embroider-safe
+          - embroider-optimized
 
     steps:
       - uses: actions/checkout@v2

--- a/addon/resolvers/classic/index.js
+++ b/addon/resolvers/classic/index.js
@@ -21,8 +21,8 @@ export class ModuleRegistry {
   has(moduleName) {
     return moduleName in this._entries;
   }
-  get(moduleName) {
-    return require(moduleName);
+  get(...args) {
+    return require(...args);
   }
 }
 
@@ -471,7 +471,7 @@ const Resolver = EmberObject.extend({
   },
 
   _extractDefaultExport(normalizedModuleName) {
-    let module = require(normalizedModuleName, null, null, true /* force sync */);
+    let module = this._moduleRegistry.get(normalizedModuleName, null, null, true /* force sync */);
 
     if (module && module['default']) {
       module = module['default'];


### PR DESCRIPTION



For embroider tests:

* [x] inline module `define` are being re-written by embroider confusing the test. Maybe we can use a noconflict loader instead.

```
not ok 2 Chrome 92.0 - [1 ms] - TestLoader Failures: dummy/tests/unit/exports-test: could not be loaded
    ---
        actual: >
            null
        stack: >
            TypeError: (0 , _externals_qunit__WEBPACK_IMPORTED_MODULE_0__.module) is not a function
                at eval (webpack://dummy/./tests/unit/exports-test.js?:10:57)
                at Object../tests/unit/exports-test.js (http://localhost:7357/assets/chunk.6024f09b703bdf0ca33a.js:51:1)
                at __webpack_require__ (http://localhost:7357/assets/chunk.6024f09b703bdf0ca33a.js:96:41)
                at Module.eval [as callback] (webpack://dummy/./assets/test.js?:190:10)
                at Module.exports (http://localhost:7357/assets/vendor.js:112:32)
                at requireModule (http://localhost:7357/assets/vendor.js:33:18)
                at TestLoader.eval (webpack://dummy/../../node_modules/ember-cli-test-loader/test-support/index.js?:95:16)
                at TestLoader.require (webpack://dummy/../../node_modules/ember-cli-test-loader/test-support/index.js?:85:25)
                at TestLoader.loadModules (webpack://dummy/../../node_modules/ember-cli-test-loader/test-support/index.js?:76:14)
                at loadTests (webpack://dummy/../../node_modules/ember-qunit/test-loader.js?:88:20)
                
```
