### PR TITLE
Bugfix/types: `Resolver extends EmberObject`

### DIFF
--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -1,2 +1,4 @@
 import { Resolver as ResolverContract } from "@ember/owner";
+import EmberObject from "@ember/object";
+export default class Resolver extends EmberObject {}
 export default interface Resolver extends Required<ResolverContract> {}


### PR DESCRIPTION
Without this, it doesn't get exported as a class people can actually instantiate with `Resolver.create()`. Whoops!