### PR TITLE
Drop support for Ember 3.x, add 4.8 to CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -62,9 +62,8 @@ jobs:
       fail-fast: false
       matrix:
         ember-try-scenario:
-          - ember-lts-3.24
-          - ember-lts-3.28
           - ember-lts-4.4
+          - ember-lts-4.8
           - ember-release
           - ember-beta
           - ember-canary

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -44,26 +44,18 @@ module.exports = async function() {
 
     scenarios: [
       {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.24.0'
-          }
-        }
-      },
-      {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0'
-          }
-        }
-      },
-      {
         name: 'ember-lts-4.4',
         npm: {
           devDependencies: {
             'ember-source': '~4.4.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-4.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.8.0'
           }
         }
       },


### PR DESCRIPTION
We already landed breaking changes dropping earlier Ember 3.x (#774), Ember CLI 2.x (#758), and Node versions (#757) quite some time ago; so we should *also* drop support for Ember 3 while we're here (3.28 is out of regular LTS for a bit now, and will go out of security releases in a few weeks).