### PR TITLE
Fix lockfile after release.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,11 @@
 {
   "name": "ember-resolver",
+  "version": "9.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "version": "9.0.0",
       "workspaces": [
         "addon",
         "test-app"
@@ -24,7 +26,7 @@
     },
     "addon": {
       "name": "ember-resolver",
-      "version": "8.0.3",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "ember-cli-babel": "^7.26.11"
@@ -26678,7 +26680,7 @@
       }
     },
     "test-app": {
-      "version": "8.0.3",
+      "version": "9.0.0",
       "license": "MIT",
       "devDependencies": {
         "@ember/optional-features": "^2.0.0",
@@ -26694,7 +26696,7 @@
         "ember-disable-prototype-extensions": "^1.1.3",
         "ember-load-initializers": "^2.1.2",
         "ember-qunit": "^5.1.5",
-        "ember-resolver": "8.0.3",
+        "ember-resolver": "9.0.0",
         "ember-source": "~4.9.3",
         "ember-source-channel-url": "^3.0.0",
         "ember-try": "^2.0.0",
@@ -45979,7 +45981,7 @@
         "ember-disable-prototype-extensions": "^1.1.3",
         "ember-load-initializers": "^2.1.2",
         "ember-qunit": "^5.1.5",
-        "ember-resolver": "8.0.3",
+        "ember-resolver": "9.0.0",
         "ember-source": "~4.9.3",
         "ember-source-channel-url": "^3.0.0",
         "ember-try": "^2.0.0",


### PR DESCRIPTION
Running `npm install` gets new entries b/c it didn't get changed during the 9.0.0 release. Lovely!