### PR TITLE
Backport types to 8.x

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+import { Resolver as ResolverContract } from "@ember/owner";
+export default interface Resolver extends Required<ResolverContract> {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,4 @@
 import { Resolver as ResolverContract } from "@ember/owner";
+import EmberObject from "@ember/object";
+export default class Resolver extends EmberObject {}
 export default interface Resolver extends Required<ResolverContract> {}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "bugs": {
     "url": "https://github.com/ember-cli/ember-resolver/issues"
   },
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ember-cli/ember-resolver.git"

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,7 +1,7 @@
-import Application from '@ember/application';
-import Resolver from './resolver';
-import loadInitializers from 'ember-load-initializers';
-import config from './config/environment';
+import Application from "@ember/application";
+import Resolver from "./resolver";
+import loadInitializers from "ember-load-initializers";
+import config from "./config/environment";
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;
@@ -10,3 +10,10 @@ export default class App extends Application {
 }
 
 loadInitializers(App, config.modulePrefix);
+
+// Makes Ember's type definitions visible throughout the project, thereby using
+// TS to power autocomplete for all Ember types in any editor.
+/**
+ * @typedef {import('ember-source/types')} Stable
+ * @typedef {import('ember-source/types/preview')} Preview
+ */


### PR DESCRIPTION
This just back-ports af9db19 and 769ad35 from the v9.0.0 release to v8.x so make it possible for folks to get native types here (still using `@types` packages) while still on Ember 3.x. We'll release this as 8.1.0.