### PR TITLE
Add @ember/string as a peerDep

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {},
   "peerDependencies": {
+    "@ember/string": "^3.0.1",
     "ember-source": "^4.8.3"
   },
   "peerDependenciesMeta": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "node": "14.* || 16.* || >= 18"
       },
       "peerDependencies": {
+        "@ember/string": "^3.0.1",
         "ember-source": "^4.8.3"
       },
       "peerDependenciesMeta": {
@@ -1744,6 +1745,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@ember/string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ember/string/-/string-3.0.1.tgz",
+      "integrity": "sha512-ntnmXS+upOWVXE+rVw2l03DjdMnaGdWbYVUxUBuPJqnIGZu2XFRsoXc7E6mOw62s8i1Xh1RgTuFHN41QGIolEQ==",
+      "dependencies": {
+        "ember-cli-babel": "^7.26.6"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/@ember/test-helpers": {
@@ -26642,6 +26654,7 @@
       "license": "MIT",
       "devDependencies": {
         "@ember/optional-features": "^2.0.0",
+        "@ember/string": "^3.0.1",
         "@ember/test-helpers": "^2.8.1",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -27832,6 +27845,14 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "@ember/string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ember/string/-/string-3.0.1.tgz",
+      "integrity": "sha512-ntnmXS+upOWVXE+rVw2l03DjdMnaGdWbYVUxUBuPJqnIGZu2XFRsoXc7E6mOw62s8i1Xh1RgTuFHN41QGIolEQ==",
+      "requires": {
+        "ember-cli-babel": "^7.26.6"
       }
     },
     "@ember/test-helpers": {
@@ -45894,6 +45915,7 @@
       "version": "file:test-app",
       "requires": {
         "@ember/optional-features": "^2.0.0",
+        "@ember/string": "^3.0.1",
         "@ember/test-helpers": "^2.8.1",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -29,6 +29,7 @@
   "dependencies": {},
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
`@ember/string` without the external package is deprecated in `ember-source` v4.10