### PR TITLE
Loosen peer dependency on ember-source to support ember-source >= v5.0

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {},
   "peerDependencies": {
     "@ember/string": "^3.0.1",
-    "ember-source": "^4.8.3"
+    "ember-source": "^4.8.3 || >= 5.0.0"
   },
   "peerDependenciesMeta": {
     "ember-source": {


### PR DESCRIPTION
Without this change, folks using `npm9` cannot create ember projects.