### PR TITLE
fix: update docs around pluralizedTypes and type the field

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ import Resolver from 'ember-resolver';
 
 export default class AppResolver extends Resolver {
   pluralizedTypes = {
+    ...this.pluralizedTypes,
     'sheep': 'sheep',
     'strategy': 'strategies'
   }

--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -1,4 +1,6 @@
 import { Resolver as ResolverContract } from "@ember/owner";
 import EmberObject from "@ember/object";
 export default class Resolver extends EmberObject {}
-export default interface Resolver extends Required<ResolverContract> {}
+export default interface Resolver extends Required<ResolverContract> {
+    pluralizedTypes: Record<string, string>;
+}


### PR DESCRIPTION
In #902 resolver was converted to native class which has a different semantics around object initialization.

Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields

> Public instance fields are added to the instance either at construction time in the base class (before the constructor body runs), *or just after `super()` returns in a subclass*.

If you define `pluralizedTypes` in the app, previously the following lines run in `init()` hook,which runs *after* properties assigned to the class instance in the child class.

```js
if (!this.pluralizedTypes.config) {
  this.pluralizedTypes.config = 'config';
}
```

now, above lines run *before* properties assigned to the class instance in the child class. Which means, `pluralizedTypes` defined in the child class overrides `config` mapping.

Because of this semantic change, any addon doing `application.resolveRegistration('config:environment')` would receive `undefined` instead of reference to the app config.

Docs should anyway teach updated syntax of `pluralizedTypes`definition.

We may argue if addons doing the right thing here or not (I would think latter is true as addons should migrate to `@embroider/macros` and utilize `getOwnConfig`, `getConfig`, and `getGlobalConfig`), but that's out of scope of this issue.

EDIT: no tests added here as there is actually nothing wrong with the addon code, it's just an app code needs to be updated.