### PR TITLE
Loosen peer dependency on ember-source to support ember-source 4.x

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {},
   "peerDependencies": {
-    "ember-source": "^4.8.3 || >= 5.0.0"
+    "ember-source": "^3.8 || ^4.0.0 || >= 5.0.0"
   },
   "peerDependenciesMeta": {
     "ember-source": {


### PR DESCRIPTION
ember-resolver should support ember 4.4, since it is an LTS version still tested against in the default blueprints.

I relaxed the restriction to 4.x and 3.8. Is this a too broad peer dependency?

