### PR TITLE
Do not use global ember -- drop support for ember-source < 4.12

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -66,8 +66,6 @@ jobs:
       fail-fast: false
       matrix:
         ember-try-scenario:
-          - ember-lts-4.4
-          - ember-lts-4.8
           - ember-lts-4.12
           - ember-lts-5.4
           - ember-lts-5.8

--- a/addon/addon/index.js
+++ b/addon/addon/index.js
@@ -5,21 +5,8 @@ import EmberObject from '@ember/object';
 import { dasherize, classify, underscore } from './string';
 import { DEBUG } from '@glimmer/env';
 import classFactory from './utils/class-factory';
-import {
-  macroCondition,
-  dependencySatisfies,
-  importSync,
-} from '@embroider/macros';
 
-let getOwner;
-
-if (macroCondition(dependencySatisfies('ember-source', '>= 4.11'))) {
-  getOwner = importSync('@ember/owner').getOwner;
-} else {
-  getOwner = importSync('@ember/application').getOwner;
-}
-
-import { TEMPLATES } from './template-cache';
+import { getOwner } from '@ember/owner';
 
 if (typeof requirejs.entries === 'undefined') {
   requirejs.entries = requirejs._eak_seen;
@@ -307,11 +294,7 @@ class Resolver extends EmberObject {
   }
 
   resolveTemplate(parsedName) {
-    let resolved = this.resolveOther(parsedName);
-    if (resolved == null) {
-      resolved = TEMPLATES[parsedName.fullNameWithoutType];
-    }
-    return resolved;
+    return this.resolveOther(parsedName);
   }
 
   mainModuleName(parsedName) {

--- a/addon/addon/index.js
+++ b/addon/addon/index.js
@@ -5,7 +5,19 @@ import EmberObject from '@ember/object';
 import { dasherize, classify, underscore } from './string';
 import { DEBUG } from '@glimmer/env';
 import classFactory from './utils/class-factory';
-import { getOwner } from '@ember/owner';
+import {
+  macroCondition,
+  dependencySatisfies,
+  importSync,
+} from '@embroider/macros';
+
+let getOwner;
+
+if (macroCondition(dependencySatisfies('ember-source', '>= 4.11'))) {
+  getOwner = importSync('@ember/owner').getOwner;
+} else {
+  getOwner = importSync('@ember/application').getOwner;
+}
 
 import { TEMPLATES } from './template-cache';
 

--- a/addon/addon/index.js
+++ b/addon/addon/index.js
@@ -1,11 +1,13 @@
 /* globals requirejs, require */
 
-import Ember from 'ember';
 import { assert, deprecate, warn } from '@ember/debug';
 import EmberObject from '@ember/object';
 import { dasherize, classify, underscore } from './string';
 import { DEBUG } from '@glimmer/env';
 import classFactory from './utils/class-factory';
+import { getOwner } from '@ember/owner';
+
+import { TEMPLATES } from './template-cache';
 
 if (typeof requirejs.entries === 'undefined') {
   requirejs.entries = requirejs._eak_seen;
@@ -295,7 +297,7 @@ class Resolver extends EmberObject {
   resolveTemplate(parsedName) {
     let resolved = this.resolveOther(parsedName);
     if (resolved == null) {
-      resolved = Ember.TEMPLATES[parsedName.fullNameWithoutType];
+      resolved = TEMPLATES[parsedName.fullNameWithoutType];
     }
     return resolved;
   }
@@ -459,7 +461,9 @@ class Resolver extends EmberObject {
 
   // only needed until 1.6.0-beta.2 can be required
   _logLookup(found, parsedName, description) {
-    if (!Ember.ENV.LOG_MODULE_RESOLVER && !parsedName.root.LOG_RESOLVER) {
+    let owner = getOwner(this);
+    let env = owner?.resolveRegistration?.('config:environment');
+    if (!env?.LOG_MODULE_RESOLVER && !parsedName.root.LOG_RESOLVER) {
       return;
     }
 

--- a/addon/addon/template-cache.js
+++ b/addon/addon/template-cache.js
@@ -1,0 +1,8 @@
+/**
+ * Originally: https://github.com/emberjs/ember.js/blob/28444d536fa20debef2a67e2f18c5eb11113a4b5/packages/%40ember/-internals/glimmer/lib/template_registry.ts#L9
+ *
+ * import { TEMPLATES } from 'ember';
+ *
+ * Removed for RFC 1003
+ */
+export let TEMPLATES = {};

--- a/addon/addon/template-cache.js
+++ b/addon/addon/template-cache.js
@@ -1,8 +1,0 @@
-/**
- * Originally: https://github.com/emberjs/ember.js/blob/28444d536fa20debef2a67e2f18c5eb11113a4b5/packages/%40ember/-internals/glimmer/lib/template_registry.ts#L9
- *
- * import { TEMPLATES } from 'ember';
- *
- * Removed for RFC 1003
- */
-export let TEMPLATES = {};

--- a/addon/package.json
+++ b/addon/package.json
@@ -23,7 +23,6 @@
   },
   "scripts": {},
   "dependencies": {
-    "@embroider/macros": "^1.16.2",
     "ember-cli-babel": "^7.26.11"
   },
   "peerDependencies": {

--- a/addon/package.json
+++ b/addon/package.json
@@ -23,9 +23,9 @@
   },
   "scripts": {},
   "dependencies": {
+    "@embroider/macros": "^1.16.2",
     "ember-cli-babel": "^7.26.11"
   },
-  "devDependencies": {},
   "peerDependencies": {
     "ember-source": "^4.8.3 || >= 5.0.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,9 +32,9 @@
       "version": "11.0.1",
       "license": "MIT",
       "dependencies": {
+        "@embroider/macros": "^1.16.2",
         "ember-cli-babel": "^7.26.11"
       },
-      "devDependencies": {},
       "engines": {
         "node": "14.* || 16.* || >= 18"
       },
@@ -1866,14 +1866,13 @@
       }
     },
     "node_modules/@embroider/macros": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.10.0.tgz",
-      "integrity": "sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==",
-      "devOptional": true,
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.16.2.tgz",
+      "integrity": "sha512-V7/6zkPmoZrPmoHKlmMyNmg8mUMdIOH7z4dqygQwWoMJp6EYd6agSLLXsfEkjBPHwTvNmiUd64Ey4dyBcYWhwQ==",
       "dependencies": {
-        "@embroider/shared-internals": "2.0.0",
+        "@embroider/shared-internals": "2.6.1",
         "assert-never": "^1.2.1",
-        "babel-import-util": "^1.1.0",
+        "babel-import-util": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
         "find-up": "^5.0.0",
         "lodash": "^4.17.21",
@@ -1882,13 +1881,20 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@glint/template": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@glint/template": {
+          "optional": true
+        }
       }
     },
     "node_modules/@embroider/macros/node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "devOptional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1900,16 +1906,17 @@
       }
     },
     "node_modules/@embroider/shared-internals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.0.0.tgz",
-      "integrity": "sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==",
-      "devOptional": true,
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.6.1.tgz",
+      "integrity": "sha512-STU1oDP36JQY+zpivyAfXGXadN664d+DOiVNBUW+4AAuWLVxIRWDIuFj8UxzREXZU9trZY8vOhKwKQtfEgdwSg==",
       "dependencies": {
-        "babel-import-util": "^1.1.0",
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
         "ember-rfc176-data": "^0.3.17",
         "fs-extra": "^9.1.0",
         "js-string-escape": "^1.0.1",
         "lodash": "^4.17.21",
+        "minimatch": "^3.0.4",
         "resolve-package-path": "^4.0.1",
         "semver": "^7.3.5",
         "typescript-memoize": "^1.0.1"
@@ -1922,7 +1929,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "devOptional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3860,8 +3866,7 @@
     "node_modules/assert-never": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
-      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
-      "devOptional": true
+      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw=="
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
@@ -3970,7 +3975,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "devOptional": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -4000,10 +4004,9 @@
       }
     },
     "node_modules/babel-import-util": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-1.3.0.tgz",
-      "integrity": "sha512-PPzUT17eAI18zn6ek1R3sB4Krc/MbnmT1MkZQFmyhjoaEGBVwNABhfVU9+EKcDSKrrOm9OIpGhjxukx1GCiy1g==",
-      "devOptional": true,
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.1.1.tgz",
+      "integrity": "sha512-3qBQWRjzP9NreSH/YrOEU1Lj5F60+pWSLP0kIdCWxjFHH7pX2YPHIxQ67el4gnMNfYoDxSDGcT0zpVlZ+gVtQA==",
       "engines": {
         "node": ">= 12.*"
       }
@@ -4088,15 +4091,6 @@
         "@glimmer/syntax": "^0.84.3",
         "babel-import-util": "^2.0.0"
       },
-      "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/babel-plugin-ember-template-compilation/node_modules/babel-import-util": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
-      "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw==",
-      "devOptional": true,
       "engines": {
         "node": ">= 12.*"
       }
@@ -12556,7 +12550,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "devOptional": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -12572,7 +12565,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -12834,7 +12826,6 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "devOptional": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -14936,7 +14927,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
       "integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
-      "devOptional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -15023,7 +15013,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "devOptional": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -15565,7 +15554,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "devOptional": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -15816,7 +15804,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "devOptional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -17880,7 +17867,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "devOptional": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -17895,7 +17881,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "devOptional": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -20116,7 +20101,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
       "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
-      "devOptional": true,
       "dependencies": {
         "path-root": "^0.1.1"
       },
@@ -22432,8 +22416,7 @@
     "node_modules/typescript-memoize": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/typescript-memoize/-/typescript-memoize-1.1.0.tgz",
-      "integrity": "sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg==",
-      "devOptional": true
+      "integrity": "sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg=="
     },
     "node_modules/uc.micro": {
       "version": "1.0.6",
@@ -22605,7 +22588,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "devOptional": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -23547,8 +23529,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yam": {
       "version": "1.0.0",
@@ -23641,7 +23622,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "devOptional": true,
       "engines": {
         "node": ">=10"
       },
@@ -23652,6 +23632,9 @@
     "test-app": {
       "version": "11.0.1",
       "license": "MIT",
+      "dependencies": {
+        "@embroider/macros": "^1.16.2"
+      },
       "devDependencies": {
         "@babel/eslint-parser": "^7.21.3",
         "@babel/plugin-proposal-decorators": "^7.21.0",
@@ -24934,14 +24917,13 @@
       }
     },
     "@embroider/macros": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.10.0.tgz",
-      "integrity": "sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==",
-      "devOptional": true,
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.16.2.tgz",
+      "integrity": "sha512-V7/6zkPmoZrPmoHKlmMyNmg8mUMdIOH7z4dqygQwWoMJp6EYd6agSLLXsfEkjBPHwTvNmiUd64Ey4dyBcYWhwQ==",
       "requires": {
-        "@embroider/shared-internals": "2.0.0",
+        "@embroider/shared-internals": "2.6.1",
         "assert-never": "^1.2.1",
-        "babel-import-util": "^1.1.0",
+        "babel-import-util": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
         "find-up": "^5.0.0",
         "lodash": "^4.17.21",
@@ -24953,7 +24935,6 @@
           "version": "7.5.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
           "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "devOptional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -24961,16 +24942,17 @@
       }
     },
     "@embroider/shared-internals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.0.0.tgz",
-      "integrity": "sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==",
-      "devOptional": true,
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.6.1.tgz",
+      "integrity": "sha512-STU1oDP36JQY+zpivyAfXGXadN664d+DOiVNBUW+4AAuWLVxIRWDIuFj8UxzREXZU9trZY8vOhKwKQtfEgdwSg==",
       "requires": {
-        "babel-import-util": "^1.1.0",
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
         "ember-rfc176-data": "^0.3.17",
         "fs-extra": "^9.1.0",
         "js-string-escape": "^1.0.1",
         "lodash": "^4.17.21",
+        "minimatch": "^3.0.4",
         "resolve-package-path": "^4.0.1",
         "semver": "^7.3.5",
         "typescript-memoize": "^1.0.1"
@@ -24980,7 +24962,6 @@
           "version": "7.5.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
           "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "devOptional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -26571,8 +26552,7 @@
     "assert-never": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
-      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
-      "devOptional": true
+      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw=="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -26672,8 +26652,7 @@
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "devOptional": true
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atob": {
       "version": "2.1.2",
@@ -26688,10 +26667,9 @@
       "dev": true
     },
     "babel-import-util": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-1.3.0.tgz",
-      "integrity": "sha512-PPzUT17eAI18zn6ek1R3sB4Krc/MbnmT1MkZQFmyhjoaEGBVwNABhfVU9+EKcDSKrrOm9OIpGhjxukx1GCiy1g==",
-      "devOptional": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.1.1.tgz",
+      "integrity": "sha512-3qBQWRjzP9NreSH/YrOEU1Lj5F60+pWSLP0kIdCWxjFHH7pX2YPHIxQ67el4gnMNfYoDxSDGcT0zpVlZ+gVtQA=="
     },
     "babel-loader": {
       "version": "8.2.5",
@@ -26752,14 +26730,6 @@
       "requires": {
         "@glimmer/syntax": "^0.84.3",
         "babel-import-util": "^2.0.0"
-      },
-      "dependencies": {
-        "babel-import-util": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
-          "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw==",
-          "devOptional": true
-        }
       }
     },
     "babel-plugin-filter-imports": {
@@ -31624,6 +31594,7 @@
     "ember-resolver": {
       "version": "file:addon",
       "requires": {
+        "@embroider/macros": "^1.16.2",
         "ember-cli-babel": "^7.26.11"
       }
     },
@@ -33430,7 +33401,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "devOptional": true,
       "requires": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -33439,8 +33409,7 @@
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "devOptional": true
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         }
       }
     },
@@ -33648,7 +33617,6 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "devOptional": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -35238,8 +35206,7 @@
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
-      "devOptional": true
+      "integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -35308,7 +35275,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "devOptional": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
@@ -35717,7 +35683,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "devOptional": true,
       "requires": {
         "p-locate": "^5.0.0"
       }
@@ -35956,7 +35921,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "devOptional": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -37412,7 +37376,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "devOptional": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -37421,7 +37384,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "devOptional": true,
       "requires": {
         "p-limit": "^3.0.2"
       }
@@ -39017,7 +38979,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
       "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
-      "devOptional": true,
       "requires": {
         "path-root": "^0.1.1"
       }
@@ -40450,6 +40411,7 @@
         "@babel/plugin-proposal-decorators": "^7.21.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.8.1",
+        "@embroider/macros": "*",
         "@embroider/test-setup": "^2.1.1",
         "broccoli-asset-rev": "^3.0.0",
         "ember-auto-import": "^2.6.3",
@@ -40884,8 +40846,7 @@
     "typescript-memoize": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/typescript-memoize/-/typescript-memoize-1.1.0.tgz",
-      "integrity": "sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg==",
-      "devOptional": true
+      "integrity": "sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg=="
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -41023,8 +40984,7 @@
     "universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "devOptional": true
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -41709,8 +41669,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yam": {
       "version": "1.0.0",
@@ -41788,8 +41747,7 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "devOptional": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
       "version": "11.0.1",
       "license": "MIT",
       "dependencies": {
-        "@embroider/macros": "^1.16.2",
         "ember-cli-babel": "^7.26.11"
       },
       "engines": {
@@ -31594,7 +31593,6 @@
     "ember-resolver": {
       "version": "file:addon",
       "requires": {
-        "@embroider/macros": "^1.16.2",
         "ember-cli-babel": "^7.26.11"
       }
     },
@@ -40411,7 +40409,7 @@
         "@babel/plugin-proposal-decorators": "^7.21.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.8.1",
-        "@embroider/macros": "*",
+        "@embroider/macros": "^1.16.2",
         "@embroider/test-setup": "^2.1.1",
         "broccoli-asset-rev": "^3.0.0",
         "ember-auto-import": "^2.6.3",

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -43,22 +43,6 @@ module.exports = async function () {
 
     scenarios: [
       {
-        name: 'ember-lts-4.4',
-        npm: {
-          devDependencies: {
-            'ember-source': '~4.4.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-4.8',
-        npm: {
-          devDependencies: {
-            'ember-source': '~4.8.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.12',
         npm: {
           devDependencies: {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -70,5 +70,8 @@
   },
   "volta": {
     "extends": "../package.json"
+  },
+  "dependencies": {
+    "@embroider/macros": "^1.16.2"
   }
 }

--- a/test-app/tests/unit/resolvers/classic/-setup-resolver.js
+++ b/test-app/tests/unit/resolvers/classic/-setup-resolver.js
@@ -1,9 +1,13 @@
 import Resolver, { ModuleRegistry } from 'ember-resolver';
+import { setOwner } from '@ember/owner';
 
 export let resolver;
 export let loader;
 
 export function setupResolver(options = {}) {
+  let owner = options.owner;
+  delete options.owner;
+
   if (!options.namespace) {
     options.namespace = { modulePrefix: 'appkit' };
   }
@@ -22,4 +26,8 @@ export function setupResolver(options = {}) {
   };
 
   resolver = Resolver.create(options);
+
+  if (owner) {
+    setOwner(resolver, owner);
+  }
 }

--- a/test-app/tests/unit/resolvers/classic/-setup-resolver.js
+++ b/test-app/tests/unit/resolvers/classic/-setup-resolver.js
@@ -1,5 +1,17 @@
 import Resolver, { ModuleRegistry } from 'ember-resolver';
-import { setOwner } from '@ember/owner';
+import {
+  macroCondition,
+  dependencySatisfies,
+  importSync,
+} from '@embroider/macros';
+
+let setOwner;
+
+if (macroCondition(dependencySatisfies('ember-source', '>= 4.11'))) {
+  setOwner = importSync('@ember/owner').setOwner;
+} else {
+  setOwner = importSync('@ember/application').setOwner;
+}
 
 export let resolver;
 export let loader;

--- a/test-app/tests/unit/resolvers/classic/-setup-resolver.js
+++ b/test-app/tests/unit/resolvers/classic/-setup-resolver.js
@@ -1,17 +1,6 @@
 import Resolver, { ModuleRegistry } from 'ember-resolver';
-import {
-  macroCondition,
-  dependencySatisfies,
-  importSync,
-} from '@embroider/macros';
 
-let setOwner;
-
-if (macroCondition(dependencySatisfies('ember-source', '>= 4.11'))) {
-  setOwner = importSync('@ember/owner').setOwner;
-} else {
-  setOwner = importSync('@ember/application').setOwner;
-}
+import { setOwner } from '@ember/owner';
 
 export let resolver;
 export let loader;

--- a/test-app/tests/unit/resolvers/classic/basic-test.js
+++ b/test-app/tests/unit/resolvers/classic/basic-test.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 
-import Ember from 'ember';
 import { module, test } from 'qunit';
 import { setupResolver, resolver, loader } from './-setup-resolver';
+import { TEMPLATES } from 'ember-resolver/template-cache';
 
 let originalConsoleInfo;
 
@@ -434,7 +434,7 @@ module('ember-resolver/resolvers/classic', function (hooks) {
   });
 
   test('can lookup templates via Ember.TEMPLATES', function (assert) {
-    Ember.TEMPLATES['application'] = function () {
+    TEMPLATES['application'] = function () {
       return '<h1>herp</h1>';
     };
 

--- a/test-app/tests/unit/resolvers/classic/basic-test.js
+++ b/test-app/tests/unit/resolvers/classic/basic-test.js
@@ -2,7 +2,6 @@
 
 import { module, test } from 'qunit';
 import { setupResolver, resolver, loader } from './-setup-resolver';
-import { TEMPLATES } from 'ember-resolver/template-cache';
 
 let originalConsoleInfo;
 
@@ -431,15 +430,6 @@ module('ember-resolver/resolvers/classic', function (hooks) {
 
     // TODO: these helpers not not compatible with modern ember
     // assert.expectDeprecation('Modules should not contain underscores. Attempted to lookup "appkit/bands/-steve-miller-band" which was not found. Please rename "appkit/bands/_steve-miller-band" to "appkit/bands/-steve-miller-band" instead.');
-  });
-
-  test('can lookup templates via Ember.TEMPLATES', function (assert) {
-    TEMPLATES['application'] = function () {
-      return '<h1>herp</h1>';
-    };
-
-    var template = resolver.resolve('template:application');
-    assert.ok(template, 'template should resolve');
   });
 
   test('it provides eachForType which invokes the callback for each item found', function (assert) {

--- a/test-app/tests/unit/resolvers/classic/logging-test.js
+++ b/test-app/tests/unit/resolvers/classic/logging-test.js
@@ -1,18 +1,20 @@
-import Ember from 'ember';
 import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
 import { setupResolver, resolver, loader } from './-setup-resolver';
 
 let originalConsoleInfo, logCalls;
 
 module('Logging', function (hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function () {
     originalConsoleInfo = console ? console.info : null;
     logCalls = [];
     console.info = function (arg) {
       logCalls.push(arg);
     };
-    setupResolver();
+    setupResolver({ owner: this.owner });
   });
 
   hooks.afterEach(function () {
@@ -26,7 +28,8 @@ module('Logging', function (hooks) {
       return 'is logged';
     });
 
-    Ember.ENV.LOG_MODULE_RESOLVER = true;
+    let env = this.owner.resolveRegistration('config:environment');
+    env.LOG_MODULE_RESOLVER = true;
 
     resolver.resolve('fruit:orange');
 
@@ -38,7 +41,8 @@ module('Logging', function (hooks) {
       return 'is not logged';
     });
 
-    Ember.ENV.LOG_MODULE_RESOLVER = false;
+    let env = this.owner.resolveRegistration('config:environment');
+    env.LOG_MODULE_RESOLVER = false;
 
     resolver.resolve('fruit:orange');
 


### PR DESCRIPTION
For https://github.com/emberjs/rfcs/pull/1015

If folks come across this PR and are using `Ember.Templates`, use [register](https://api.emberjs.com/ember/5.9/classes/Owner/methods/register?anchor=register) instead.