### PR TITLE
hide global require from webpack

### DIFF
--- a/addon/addon/index.js
+++ b/addon/addon/index.js
@@ -1,15 +1,13 @@
-/* globals requirejs, require */
-
 import { dasherize, classify, underscore } from './string';
 import classFactory from './utils/class-factory';
 
-if (typeof requirejs.entries === 'undefined') {
-  requirejs.entries = requirejs._eak_seen;
+if (typeof globalThis.requirejs.entries === 'undefined') {
+  globalThis.requirejs.entries = globalThis.requirejs._eak_seen;
 }
 
 export class ModuleRegistry {
   constructor(entries) {
-    this._entries = entries || requirejs.entries;
+    this._entries = entries || globalThis.requirejs.entries;
   }
   moduleNames() {
     return Object.keys(this._entries);
@@ -18,7 +16,7 @@ export class ModuleRegistry {
     return moduleName in this._entries;
   }
   get(...args) {
-    return require(...args);
+    return globalThis.require(...args);
   }
 }
 

--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -1,6 +1,8 @@
 import { Resolver as ResolverContract } from "@ember/owner";
-import EmberObject from "@ember/object";
-export default class Resolver extends EmberObject {}
+
+export default class Resolver {
+  static create(props: Record<string, unknown>): InstanceType<this>;
+}
 export default interface Resolver extends Required<ResolverContract> {
     pluralizedTypes: Record<string, string>;
 }


### PR DESCRIPTION
Bugfix on top of #977 from testing in real apps.

When using ember-auto-import you can get your `require` transpiled by webpack in a way that doesn't work. We want this to always refer to the ambient global runtime one.