### PR TITLE
Optional explicit modules

### DIFF
--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -2,6 +2,7 @@ import { Resolver as ResolverContract } from "@ember/owner";
 
 export default class Resolver {
   static create(props: Record<string, unknown>): InstanceType<this>;
+  static withModules(modules: Record<string, unknown>): this;
 }
 export default interface Resolver extends Required<ResolverContract> {
     pluralizedTypes: Record<string, string>;

--- a/test-app/tests/unit/resolvers/classic/with-modues-test.js
+++ b/test-app/tests/unit/resolvers/classic/with-modues-test.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-console */
+
+import { module, test } from 'qunit';
+import Resolver from 'ember-resolver';
+
+module('ember-resolver withModules', function () {
+  test('explicit withModules', function (assert) {
+    let resolver = Resolver.withModules({
+      'alpha/components/hello': {
+        default: function () {
+          return 'it works';
+        },
+      },
+    }).create({ namespace: { modulePrefix: 'alpha' } });
+
+    assert.strictEqual((0, resolver.resolve('component:hello'))(), 'it works');
+  });
+});


### PR DESCRIPTION
This creates an alternative way to give the resolver access to your modules.

```diff
export default class App extends Application {
  modulePrefix = config.modulePrefix;
-  Resolver = Resolver;
+  Resolver = Resolver.withModules(modulesGoHere) 
}
```

It expects a POJO with string keys and instantiated modules as values. It's intentionally eager to keep the rest of the public resolver API the same while being compatible with real ES module systems. An example of how you'd get the `modulesGoHere` value is to derive it from `import.meta.glob(..., { eager: true })` or to use a virtual backward-compatibility set of modules provided by embroider.

When you use `withModules`, the resolver will not attempt to touch `require` or `requirejs`, meaning your app can function entirely without an AMD loader.